### PR TITLE
Add Support for Third-Party PV Power Sensor and Total PV Power Calculation

### DIFF
--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -126,6 +126,32 @@ class SigenergyCalculations:
             return None
 
     @staticmethod
+    def calculate_total_pv_power(
+        _,  # value is not used for this calculation
+        coordinator_data: Optional[Dict[str, Any]] = None,
+        extra_params: Optional[Dict[str, Any]] = None, # Not used here, but kept for consistency
+    ) -> Optional[float]:
+        """Calculate the total PV power from plant and party sources."""
+        if not coordinator_data or "plant" not in coordinator_data:
+            _LOGGER.debug("[CS][Total PV Power] Missing plant data in coordinator_data for total PV power calculation")
+            return None
+
+        plant_data = coordinator_data.get("plant", {})
+
+        plant_pv_power = safe_float(
+            plant_data.get("plant_photovoltaic_power"))
+        thirdparty_pv_power = safe_float(
+            plant_data.get("plant_third_party_photovoltaic_power"))
+
+        # If either value is None after safe_float, it means it was invalid or missing.
+        # We treat missing as 0 for summation, but if both are missing, return None.
+        if plant_pv_power is None and thirdparty_pv_power is None:
+            _LOGGER.debug("[CS][Total PV Power] Both plant_photovoltaic_power and thirdparty_pv_power are unavailable.")
+            return None
+
+        return (plant_pv_power or 0.0) + (thirdparty_pv_power or 0.0)
+
+    @staticmethod
     def calculate_pv_power(
         _,
         coordinator_data: Optional[Dict[str, Any]] = None,
@@ -1061,6 +1087,18 @@ class SigenergyCalculatedSensors:
                 EMSWorkMode.REMOTE_EMS: "Remote EMS",
                 EMSWorkMode.TIME_BASED_CONTROL: "Time-Based Control",
             }.get(value, f"Unknown: ({value})"), # Fallback to original value
+        ),
+        SigenergySensorEntityDescription(
+            key="plant_photovoltaic_power",
+            name="PV Power",
+            device_class=SensorDeviceClass.POWER,
+            native_unit_of_measurement=UnitOfPower.KILO_WATT,
+            state_class=SensorStateClass.MEASUREMENT,
+            icon="mdi:solar-power",
+            value_fn=SigenergyCalculations.calculate_total_pv_power,
+            extra_fn_data=True,  # Pass coordinator data to value_fn
+            suggested_display_precision=3,
+            round_digits=6,
         ),
         SigenergySensorEntityDescription(
             key="plant_grid_import_power",

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -48,7 +48,7 @@ LOG_THIS_ENTITY = [
     # "sensor.sigen_plant_accumulated_grid_import_energy",
     # "sensor.sigen_plant_accumulated_pv_energy",
     # "sigen_plant_accumulated_battery_charge_energy",
-    "sensor.sigen_plant_accumulated_pv_energy",
+    # "sensor.sigen_plant_accumulated_pv_energy",
     # "sensor.sigen_plant_daily_pv_energy",
 ]
 

--- a/custom_components/sigen/modbusregisterdefinitions.py
+++ b/custom_components/sigen/modbusregisterdefinitions.py
@@ -420,6 +420,16 @@ PLANT_RUNNING_INFO_REGISTERS = {
         description="Photovoltaic power",
         update_frequency=UpdateFrequencyType.HIGH,
     ),
+    "plant_third-party_photovoltaic_power": ModbusRegisterDefinition(
+        address=30194,
+        count=2,
+        register_type=RegisterType.READ_ONLY,
+        data_type=DataType.S32,
+        gain=1000,
+        unit=UnitOfPower.KILO_WATT,
+        description="Photovoltaic power",
+        update_frequency=UpdateFrequencyType.HIGH,
+    ),
     "plant_ess_power": ModbusRegisterDefinition(
         address=30037,
         count=2,

--- a/custom_components/sigen/modbusregisterdefinitions.py
+++ b/custom_components/sigen/modbusregisterdefinitions.py
@@ -410,7 +410,7 @@ PLANT_RUNNING_INFO_REGISTERS = {
         description="Plant reactive power",
         update_frequency=UpdateFrequencyType.HIGH,
     ),
-    "plant_photovoltaic_power": ModbusRegisterDefinition(
+    "plant_sigen_photovoltaic_power": ModbusRegisterDefinition(
         address=30035,
         count=2,
         register_type=RegisterType.READ_ONLY,
@@ -420,7 +420,7 @@ PLANT_RUNNING_INFO_REGISTERS = {
         description="Photovoltaic power",
         update_frequency=UpdateFrequencyType.HIGH,
     ),
-    "plant_third-party_photovoltaic_power": ModbusRegisterDefinition(
+    "plant_third_party_photovoltaic_power": ModbusRegisterDefinition(
         address=30194,
         count=2,
         register_type=RegisterType.READ_ONLY,

--- a/custom_components/sigen/static_sensor.py
+++ b/custom_components/sigen/static_sensor.py
@@ -204,6 +204,15 @@ class StaticSensors:
             icon="mdi:solar-power",
         ),
         SigenergySensorEntityDescription(
+            key="plant_third-party_photovoltaic_power",
+            name="Third-Party PV Power",
+            device_class=SensorDeviceClass.POWER,
+            native_unit_of_measurement=UnitOfPower.KILO_WATT,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=3,
+            icon="mdi:solar-power",
+        ),
+        SigenergySensorEntityDescription(
             key="plant_ess_power",
             name="Battery Power",
             device_class=SensorDeviceClass.POWER,

--- a/custom_components/sigen/static_sensor.py
+++ b/custom_components/sigen/static_sensor.py
@@ -195,8 +195,8 @@ class StaticSensors:
             entity_registry_enabled_default=False,
         ),
         SigenergySensorEntityDescription(
-            key="plant_photovoltaic_power",
-            name="PV Power",
+            key="plant_sigen_photovoltaic_power",
+            name="Sigen PV Power",
             device_class=SensorDeviceClass.POWER,
             native_unit_of_measurement=UnitOfPower.KILO_WATT,
             state_class=SensorStateClass.MEASUREMENT,
@@ -204,7 +204,7 @@ class StaticSensors:
             icon="mdi:solar-power",
         ),
         SigenergySensorEntityDescription(
-            key="plant_third-party_photovoltaic_power",
+            key="plant_third_party_photovoltaic_power",
             name="Third-Party PV Power",
             device_class=SensorDeviceClass.POWER,
             native_unit_of_measurement=UnitOfPower.KILO_WATT,


### PR DESCRIPTION
Adds support for a new Modbus register to track third-party photovoltaic power.

Implements a utility function calculate_total_pv_power to aggregate PV power from both plant and third-party sources.

Updates custom_components/sigen/calculated_sensor.py to include the new computed sensor for total PV power, ensuring better data representation.

Updates register definitions and sensor descriptions across relevant modules to reflect new keys and consistent naming.