### PR TITLE
Enhance PV Power Calculations and Update Binary Sensor Logic

### DIFF
--- a/custom_components/sigen/manifest.json
+++ b/custom_components/sigen/manifest.json
@@ -21,5 +21,5 @@
   "loggers": ["custom_components.sigen"],
   "quality_scale": "custom",
   "requirements": ["pymodbus>=3.0.0"],
-  "version": "1.0.8"
+  "version": "1.0.10"
 }


### PR DESCRIPTION
Enhance PV Power Calculations and Update Binary Sensor Logic

Introduces support for third-party PV input via plant_third_party_photovoltaic_power.

Updates calculate_total_pv_power to return a safe float aggregate of plant and third-party sources.

Refactors binary sensor logic in binary_sensor.py to rely on dynamic PV power calculations instead of static keys.

Improves accuracy of plant_consumed_power by utilizing the updated total PV power metric.

Bumps version to 1.0.10 in manifest.json to reflect major functional improvement.