### PR TITLE
swap import and export icons

### DIFF
--- a/custom_components/sigen/binary_sensor.py
+++ b/custom_components/sigen/binary_sensor.py
@@ -75,7 +75,8 @@ PLANT_BINARY_SENSORS: list[SigenergyBinarySensorEntityDescription] = [
         key="plant_exporting_to_grid",
         name="Exporting to Grid",
         device_class=BinarySensorDeviceClass.POWER,
-        icon="mdi:transmission-tower-export",
+        # 'tower-import' icon means 'energy to grid'
+        icon="mdi:transmission-tower-import",
         source_key="plant_grid_sensor_active_power",
         # Exporting is when grid power is positive (Sigenergy convention)
         value_fn=lambda data: (dec_val := safe_decimal(data.get("plant_grid_sensor_active_power"))) is not None and dec_val < Decimal("-0.01"),
@@ -84,7 +85,8 @@ PLANT_BINARY_SENSORS: list[SigenergyBinarySensorEntityDescription] = [
         key="plant_importing_from_grid",
         name="Importing from Grid",
         device_class=BinarySensorDeviceClass.POWER,
-        icon="mdi:transmission-tower-import",
+        # 'tower-export' icon means 'energy from grid'
+        icon="mdi:transmission-tower-export",
         source_key="plant_grid_sensor_active_power",
         # Importing is when grid power is negative (Sigenergy convention)
         value_fn=lambda data: (dec_val := safe_decimal(data.get("plant_grid_sensor_active_power"))) is not None and dec_val > Decimal("0.01"),

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -1528,7 +1528,8 @@ class SigenergyCalculatedSensors:
             device_class=SensorDeviceClass.ENERGY,
             native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             state_class=SensorStateClass.TOTAL_INCREASING,
-            icon="mdi:transmission-tower-import",
+            # 'tower-export' icon means 'energy from grid'
+            icon="mdi:transmission-tower-export",
             value_fn=SigenergyCalculations.calculate_daily_energy_from_lifetime,
             extra_fn_data=True,
             extra_params={
@@ -1543,7 +1544,8 @@ class SigenergyCalculatedSensors:
             device_class=SensorDeviceClass.ENERGY,
             native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             state_class=SensorStateClass.TOTAL_INCREASING,
-            icon="mdi:transmission-tower-export",
+            # 'tower-import' icon means 'energy to grid'
+            icon="mdi:transmission-tower-import",
             value_fn=SigenergyCalculations.calculate_daily_energy_from_lifetime,
             extra_fn_data=True,
             extra_params={

--- a/custom_components/sigen/number.py
+++ b/custom_components/sigen/number.py
@@ -154,7 +154,8 @@ PLANT_NUMBERS = [
     SigenergyNumberEntityDescription(
         key="plant_grid_point_maximum_export_limitation",
         name="Grid Export Limitation",
-        icon="mdi:transmission-tower-export",
+        # 'tower-import' icon means 'energy to grid'
+        icon="mdi:transmission-tower-import",
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         native_min_value=0,
         native_max_value=100,
@@ -167,7 +168,8 @@ PLANT_NUMBERS = [
     SigenergyNumberEntityDescription(
         key="plant_grid_maximum_import_limitation",
         name="Grid Import Limitation",
-        icon="mdi:transmission-tower-import",
+        # 'tower-export' icon means 'energy from grid'
+        icon="mdi:transmission-tower-export",
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         native_min_value=0,
         native_max_value=100,


### PR DESCRIPTION
These icons are designed from the perspective of the grid.

"tower-import" means the grid is importing power. See https://pictogrammers.com/library/mdi/icon/transmission-tower-import/ - it has the explanatory tags 'power-to-grid', 'energy-to-grid', etc. 

From the SigenStor perspective, this is when the SigenStor is sending/exporting power to the grid.

So when the local system is 'exporting', we need to use the 'tower-import' icon. And vice versa for when the system is importing.