### PR TITLE
Enable plant rated sensors by default

### DIFF
--- a/custom_components/sigen/static_sensor.py
+++ b/custom_components/sigen/static_sensor.py
@@ -78,7 +78,6 @@ class StaticSensors:
             native_unit_of_measurement=UnitOfPower.KILO_WATT,
             state_class=SensorStateClass.MEASUREMENT,
             entity_category=EntityCategory.DIAGNOSTIC,
-            entity_registry_enabled_default=False,
         ),
         SigenergySensorEntityDescription(
             key="plant_max_apparent_power",
@@ -338,7 +337,6 @@ class StaticSensors:
             native_unit_of_measurement=UnitOfPower.KILO_WATT,
             state_class=SensorStateClass.MEASUREMENT,
             entity_category=EntityCategory.DIAGNOSTIC,
-            entity_registry_enabled_default=False,
         ),
         SigenergySensorEntityDescription(
             key="plant_ess_rated_discharging_power",
@@ -347,7 +345,6 @@ class StaticSensors:
             native_unit_of_measurement=UnitOfPower.KILO_WATT,
             state_class=SensorStateClass.MEASUREMENT,
             entity_category=EntityCategory.DIAGNOSTIC,
-            entity_registry_enabled_default=False,
         ),
         SigenergySensorEntityDescription(
             key="plant_ess_available_max_charging_capacity",
@@ -374,7 +371,6 @@ class StaticSensors:
             native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             state_class=SensorStateClass.TOTAL,
             entity_category=EntityCategory.DIAGNOSTIC,
-            entity_registry_enabled_default=False,
         ),
         SigenergySensorEntityDescription(
             key="plant_ess_charge_cut_off_soc",


### PR DESCRIPTION
These 4 sensors allow a great deal of automation when it comes to running optimization systems such as [EMHASS](https://emhass.readthedocs.io/en/latest/).

- `plant_max_active_power`
- `plant_ess_rated_charging_power`
- `plant_ess_rated_discharging_power`
- `plant_ess_rated_energy_capacity`

How do you feel about enabling them by default? I realise there are many sensors and enabling too many is not a good idea, but I feel like these 4 are fundamental to the characterics of the system that it would be great to enable them by default.

I have written a [tutorial](https://sigenergy.annable.me/) on EMHASS and its unfortunate that I have to direct users (who are often fairly new to home assistant) to manually enable these sensors to be able to setup their battery automations.

Any strong options? Thanks.