### PR TITLE
Fix AC charger switch state by using numeric system state values

### DIFF
--- a/custom_components/sigen/switch.py
+++ b/custom_components/sigen/switch.py
@@ -102,7 +102,7 @@ AC_CHARGER_SWITCHES: list[SigenergySwitchEntityDescription] = [
         name="AC Charger Power",
         icon="mdi:ev-station",
         # identifier here will be ac_charger_name
-        is_on_fn=lambda data, identifier: data.get("ac_chargers", {}).get(identifier, {}).get("ac_charger_system_state") not in ("Initializing", "Fault", "Error", "Not Connected"),
+        is_on_fn=lambda data, identifier: data.get("ac_chargers", {}).get(identifier, {}).get("ac_charger_system_state") in (3,4,5),
         turn_on_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 0),
         turn_off_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 1),
     ),


### PR DESCRIPTION
The AC charger system state is stored internally as a numeric enum value, not a mapped string.

The previous switch logic compared the state against string values ("Initializing", "Fault", etc.), which caused the switch to never correctly reflect the charger state.

This change updates is_on_fn to rely on the numeric system state values reported by the charger. Currently treating states 3, 4, and 5 as ON.

This aligns the AC charger switch behavior with how other switches (e.g. plant_start_stop) determine their state.

Verified to work correctly after Modbus refresh on Home Assistant with a Sigenergy EVAC system.