### PR TITLE
Add VPP Scheduling EMS Work Mode

### DIFF
--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -1621,6 +1621,7 @@ class SigenergyCalculatedSensors:
                 EMSWorkMode.AI_MODE: "AI Mode",
                 EMSWorkMode.TOU: "Time of Use",
                 EMSWorkMode.FULL_FEED_IN_TO_GRID: "Full Feed-In to Grid",
+                EMSWorkMode.VPP_SCHEDULING: "VPP Scheduling",
                 EMSWorkMode.REMOTE_EMS: "Remote EMS",
                 EMSWorkMode.CUSTOM: "Custom",
             }.get(value, f"Unknown: ({value})"), # Fallback to original value

--- a/custom_components/sigen/modbusregisterdefinitions.py
+++ b/custom_components/sigen/modbusregisterdefinitions.py
@@ -139,6 +139,7 @@ class EMSWorkMode(IntEnum):
     AI_MODE = 1
     TOU = 2
     FULL_FEED_IN_TO_GRID = 5
+    VPP_SCHEDULING = 6
     REMOTE_EMS = 7
     CUSTOM = 9
 


### PR DESCRIPTION
Adds support for the `VPP_SCHEDULING` work mode. Validated against the value (`6`) recieved during Axle VPP events, and the label which appears in the Sig app. 