### PR TITLE
Remove hardcoded battery icon for Battery State of Charge

### DIFF
--- a/custom_components/sigen/static_sensor.py
+++ b/custom_components/sigen/static_sensor.py
@@ -97,7 +97,8 @@ class StaticSensors:
             device_class=SensorDeviceClass.BATTERY,
             native_unit_of_measurement=PERCENTAGE,
             state_class=SensorStateClass.MEASUREMENT,
-            icon="mdi:battery",
+            # Intentionally no hardcoded icon: allow Home Assistant to use
+            # the default dynamic battery icon based on SOC.
         ),
         SigenergySensorEntityDescription(
             key="plant_phase_a_active_power",

--- a/custom_components/sigen/static_sensor.py
+++ b/custom_components/sigen/static_sensor.py
@@ -1300,7 +1300,8 @@ class StaticSensors:
             device_class=SensorDeviceClass.BATTERY,
             native_unit_of_measurement=PERCENTAGE,
             state_class=SensorStateClass.MEASUREMENT,
-            icon="mdi:battery",
+            # Intentionally no hardcoded icon: allow Home Assistant to use
+            # the default dynamic battery icon based on SOC.
         ),
         SigenergySensorEntityDescription(
             key="inverter_ess_battery_soh",
@@ -1770,7 +1771,8 @@ class StaticSensors:
             device_class=SensorDeviceClass.BATTERY,
             native_unit_of_measurement=PERCENTAGE,
             state_class=SensorStateClass.MEASUREMENT,
-            icon="mdi:battery",
+            # Intentionally no hardcoded icon: allow Home Assistant to use
+            # the default dynamic battery icon based on SOC.
         ),
         SigenergySensorEntityDescription(
             key="dc_charger_current_charging_capacity",


### PR DESCRIPTION
This removes the hardcoded icon from the plant_ess_soc sensor description.

Home Assistant already provides a default dynamic battery icon for sensors with device_class=battery and SOC in %, but setting icon=mdi:battery forces a static icon.

Fixes #305.