### PR TITLE
Fix daily energy zero-bounce spikes during reconnect

### DIFF
--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -404,6 +404,7 @@ class SigenergyCalculations:
             return None
 
         total_energy = Decimal("0.0")
+        valid_sample_count = 0
         inverters_data = coordinator_data.get("inverters", {})
 
         if not inverters_data:
@@ -415,6 +416,7 @@ class SigenergyCalculations:
             if energy_value is not None:
                 try:
                     total_energy += energy_value
+                    valid_sample_count += 1
                 except (ValueError, TypeError, InvalidOperation) as e:
                     _LOGGER.warning(
                         "[%s] Invalid energy value '%s' for key '%s' in inverter %s: %s",
@@ -431,6 +433,12 @@ class SigenergyCalculations:
                     energy_key,
                     inverter_name
                  )
+
+        # If every inverter value was missing/invalid, publish unavailable instead of 0
+        # to avoid zero-bounce spikes in Energy Dashboard after reconnection events.
+        if valid_sample_count == 0:
+            _LOGGER.debug("[%s] No valid '%s' samples in this poll", log_prefix, energy_key)
+            return None
 
         # Return as Decimal, matching other calculated sensors
         return safe_decimal(total_energy)

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -412,7 +412,17 @@ class SigenergyCalculations:
             return None # No inverters found
 
         for inverter_name, inverter_data in inverters_data.items():
-            energy_value = safe_decimal(inverter_data.get(energy_key))
+            raw_value = inverter_data.get(energy_key)
+            if raw_value is None:
+                _LOGGER.debug(
+                    "[%s] Missing '%s' for inverter %s",
+                    log_prefix,
+                    energy_key,
+                    inverter_name,
+                )
+                continue
+
+            energy_value = safe_decimal(raw_value)
             if energy_value is not None:
                 try:
                     total_energy += energy_value
@@ -428,10 +438,11 @@ class SigenergyCalculations:
                     )
             else:
                 _LOGGER.debug(
-                    "[%s] Missing '%s' for inverter %s",
+                    "[%s] Invalid '%s' value '%s' for inverter %s",
                     log_prefix,
                     energy_key,
-                    inverter_name
+                    raw_value,
+                    inverter_name,
                  )
 
         # If every inverter value was missing/invalid, publish unavailable instead of 0

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -274,7 +274,7 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
             and self._last_valid_daily_energy_value > 0
             and not self._is_near_daily_reset()
         ):
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "[%s] Ignoring transient daily energy drop to 0 outside reset window (last=%s)",
                 self.entity_id,
                 self._last_valid_daily_energy_value,

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional, cast
 from decimal import Decimal, InvalidOperation
+from datetime import timedelta
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -20,6 +21,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .modbusregisterdefinitions import (
     RunningState,
@@ -35,7 +37,7 @@ from .calculated_sensor import (
 )
 from .static_sensor import StaticSensors as SS
 from .static_sensor import COORDINATOR_DIAGNOSTIC_SENSORS # Import the new descriptions
-from .common import generate_sigen_entity, generate_device_id, SigenergySensorEntityDescription, SensorEntityDescription
+from .common import generate_sigen_entity, generate_device_id, SigenergySensorEntityDescription, SensorEntityDescription, safe_decimal
 from .const import (
     DOMAIN,
     DEVICE_TYPE_PLANT,
@@ -48,6 +50,18 @@ from .const import (
 from .sigen_entity import SigenergyEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+PROTECTED_DAILY_ENERGY_KEYS = {
+    "plant_daily_pv_energy",
+    "plant_daily_battery_charge_energy",
+    "plant_daily_battery_discharge_energy",
+    "inverter_daily_pv_energy",
+    "inverter_ess_daily_charge_energy",
+    "inverter_ess_daily_discharge_energy",
+}
+
+DAILY_RESET_GUARD_WINDOW = timedelta(minutes=20)
 
 
 async def async_setup_entry(
@@ -201,6 +215,7 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
             if isinstance(description, SigenergySensorEntityDescription)
             else None
         )
+        self._last_valid_daily_energy_value: Decimal | None = None
 
     def _decode_alarm_bits(self, value: int, alarm_mapping: dict) -> str:
         """Decode alarm bits into human-readable text."""
@@ -229,6 +244,38 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
             return data.get("dc_chargers", {}).get(self._device_name, {}).get(self.entity_description.key)
         return None
 
+    def _is_near_daily_reset(self) -> bool:
+        """Return True around midnight to allow legitimate daily counter resets."""
+        now = dt_util.now()
+        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        return abs(now - midnight) <= DAILY_RESET_GUARD_WINDOW
+
+    def _apply_daily_energy_zero_guard(self, value: Any) -> Any:
+        """Prevent transient zero-bounce for daily total_increasing energy sensors."""
+        key = getattr(self.entity_description, "key", None)
+        if key not in PROTECTED_DAILY_ENERGY_KEYS:
+            return value
+
+        value_dec = safe_decimal(value)
+        if value_dec is None:
+            return value
+
+        if (
+            value_dec == 0
+            and self._last_valid_daily_energy_value is not None
+            and self._last_valid_daily_energy_value > 0
+            and not self._is_near_daily_reset()
+        ):
+            _LOGGER.warning(
+                "[%s] Ignoring transient daily energy drop to 0 outside reset window (last=%s)",
+                self.entity_id,
+                self._last_valid_daily_energy_value,
+            )
+            return None
+
+        self._last_valid_daily_energy_value = value_dec
+        return value
+
     @property
     def native_value(self) -> Any:
         """Return the state of the sensor."""
@@ -252,8 +299,8 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
 
                 # Round if needed
                 if transformed is not None and self._round_digits is not None:
-                    return round(Decimal(transformed), self._round_digits)
-                return transformed
+                    transformed = round(Decimal(transformed), self._round_digits)
+                return self._apply_daily_energy_zero_guard(transformed)
             except Exception as ex:
                 if raw_value is None:
                     _LOGGER.debug("Value function failed for %s because data is missing: %s", self.entity_id, ex)
@@ -309,15 +356,15 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
             "plant_grid_sensor_status": {0: "Offline", 1: "Online"},
         }
         if self.entity_description.key in enum_maps:
-            return enum_maps[self.entity_description.key].get(raw_value, f"Unknown: {raw_value}")
+            return self._apply_daily_energy_zero_guard(enum_maps[self.entity_description.key].get(raw_value, f"Unknown: {raw_value}"))
 
         if self._round_digits is not None:
             try:
-                return round(Decimal(raw_value), self._round_digits)
+                return self._apply_daily_energy_zero_guard(round(Decimal(raw_value), self._round_digits))
             except (TypeError, ValueError, InvalidOperation):
                 _LOGGER.warning("Could not round direct value for %s: %s", self.entity_id, raw_value)
 
-        return raw_value
+        return self._apply_daily_energy_zero_guard(raw_value)
 
 
 class PVStringSensor(SigenergySensor):

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -215,6 +215,8 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
             if isinstance(description, SigenergySensorEntityDescription)
             else None
         )
+        # In-memory only: this resets on HA restart, so the first post-restart poll
+        # has no historical reference and is intentionally passed through.
         self._last_valid_daily_energy_value: Decimal | None = None
 
     def _decode_alarm_bits(self, value: int, alarm_mapping: dict) -> str:

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -245,16 +245,22 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
         return None
 
     def _is_near_daily_reset(self) -> bool:
-        """Return True around midnight to allow legitimate daily counter resets."""
+        """Return True in a symmetric window around midnight."""
         now = dt_util.now()
-        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        return abs(now - midnight) <= DAILY_RESET_GUARD_WINDOW
+        seconds_since_midnight = (
+            now.hour * 3600 + now.minute * 60 + now.second + now.microsecond / 1_000_000
+        )
+        distance_to_midnight = min(seconds_since_midnight, 86400 - seconds_since_midnight)
+        return distance_to_midnight <= DAILY_RESET_GUARD_WINDOW.total_seconds()
 
     def _apply_daily_energy_zero_guard(self, value: Any) -> Any:
         """Prevent transient zero-bounce for daily total_increasing energy sensors."""
         key = getattr(self.entity_description, "key", None)
         if key not in PROTECTED_DAILY_ENERGY_KEYS:
             return value
+
+        if value is None:
+            return None
 
         value_dec = safe_decimal(value)
         if value_dec is None:


### PR DESCRIPTION
## Summary
This PR hardens daily `total_increasing` energy sensors against transient reconnect glitches that can cause phantom energy in the HA Energy Dashboard.

## Changes
- `custom_components/sigen/calculated_sensor.py`
  - In `_calculate_total_inverter_energy`, track valid inverter samples per poll.
  - If all values are missing/invalid, return `None` (unavailable) instead of `0.0`.

- `custom_components/sigen/sensor.py`
  - Add a guard for daily energy keys:
    - `plant_daily_pv_energy`
    - `plant_daily_battery_charge_energy`
    - `plant_daily_battery_discharge_energy`
    - `inverter_daily_pv_energy`
    - `inverter_ess_daily_charge_energy`
    - `inverter_ess_daily_discharge_energy`
  - If value drops from `>0` to `0` outside a midnight reset window, publish `None` for that cycle.
  - Keep legitimate midnight reset behavior by allowing a reset window around `00:00`.

## Why
Under transient Modbus/network interruptions, some daily counters can briefly report zero, which HA interprets as new production when values recover. This inflates statistics.

## Result
Transient reconnect glitches become `unavailable` instead of false zero resets, preventing phantom energy spikes while preserving real midnight resets.

Closes #313
