### PR TITLE
Update description for smart load 15 to smart load 16

### DIFF
--- a/custom_components/sigen/modbusregisterdefinitions.py
+++ b/custom_components/sigen/modbusregisterdefinitions.py
@@ -1014,7 +1014,7 @@ PLANT_RUNNING_INFO_REGISTERS = {
         data_type=DataType.S32,
         gain=1000,
         unit=UnitOfPower.KILO_WATT,
-        description="[Smart load 15] Power",
+        description="[Smart load 16] Power",
     ),
     "plant_smart_load_17_power": ModbusRegisterDefinition(
         address=30178,


### PR DESCRIPTION
The Smart Load 16 Power description has a typo as it says that it is for 15, instead of 16. 
All the other values for the modbus register are correct.