### PR TITLE
Calculated Sensor - (Add) Battery Current

### DIFF
--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -493,6 +493,19 @@ class SigenergyCalculations:
         )
 
     @staticmethod
+    def calculate_daily_battery_discharge_energy(
+        value,
+        coordinator_data: Optional[Dict[str, Any]] = None,
+        extra_params: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Decimal]:
+        """Calculate the total daily battery discharge energy across all inverters."""
+        return SigenergyCalculations._calculate_total_inverter_energy(
+            coordinator_data,
+            "inverter_ess_daily_discharge_energy",
+            "CS][Daily Batt Discharge"
+        )
+
+    @staticmethod
     def _identify_battery_series_cells(
         pack_count: int,
         rated_capacity_kwh: float,
@@ -518,7 +531,6 @@ class SigenergyCalculations:
         Returns:
             Total cells in series, or None if no valid combination found.
         """
-        # (capacity_kwh, cells_in_series)
         MODULE_TYPES = [
             (5.38, 6),   # 5kWh module
             (6.02, 6),   # 6kWh module
@@ -602,7 +614,7 @@ class SigenergyCalculations:
             return None
 
         return round((ess_power_kw * 1000) / system_voltage, 2)
-    
+
     @staticmethod
     def calculate_plant_daily_pv_energy(
         value,
@@ -610,7 +622,6 @@ class SigenergyCalculations:
         extra_params: Optional[Dict[str, Any]] = None,
     ) -> Optional[Decimal]:
         """Calculate the total daily PV energy across all inverters."""
-        # _LOGGER.debug("[CS][Daily PV] Calculating daily PV energy")
         return SigenergyCalculations._calculate_total_inverter_energy(
             coordinator_data,
             "inverter_daily_pv_energy",

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -1944,6 +1944,7 @@ class SigenergyCalculatedSensors:
             icon="mdi:current-dc",
             value_fn=SigenergyCalculations.calculate_ess_current,
             extra_fn_data=True,
+            entity_registry_enabled_default=False,
         ),
     ]
 

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -492,7 +492,7 @@ class SigenergyCalculations:
             "CS][Daily Batt Discharge"
         )
 
-@staticmethod
+    @staticmethod
     def _identify_battery_series_cells(
         pack_count: int,
         rated_capacity_kwh: float,

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -497,11 +497,16 @@ class SigenergyCalculations:
         rated_capacity_kwh: float,
         tolerance: float = 0.02,
     ) -> Optional[int]:
-        """Determine total cells in series across the battery stack.
+        """Determine cells in series for a single battery module.
 
         Finds the combination of Sigenergy module types that best matches
-        the given pack count and rated capacity, then returns the total
-        number of series-connected cells across all packs.
+        the given pack count and rated capacity, then returns the series
+        cell count of one module.
+
+        Modules are connected in parallel (each has a built-in DC-DC
+        optimiser). Parallel connection adds capacity while keeping voltage
+        constant, so system_voltage = cells_per_module × avg_cell_voltage
+        regardless of pack_count.
 
         The search is exhaustive over all valid combinations of module types
         that sum to pack_count, and returns the combination whose total
@@ -527,7 +532,7 @@ class SigenergyCalculations:
                                 (default 2 %).
 
         Returns:
-            Total cells in series for the best-matching combination, or
+            Cells in series per module for the best-matching combination, or
             None if no combination falls within the tolerance window.
         """
         # Sanity cap: guards against corrupt register values only.
@@ -580,7 +585,7 @@ class SigenergyCalculations:
                             + d * MODULE_TYPES[3][1]
                         )
 
-        return best_cells
+        return best_cells // pack_count if best_cells is not None else None
 
     @staticmethod
     def calculate_ess_current(
@@ -630,11 +635,11 @@ class SigenergyCalculations:
             if pack_count_int == 0 or avg_cell_voltage == 0 or not rated_capacity_kwh:
                 continue
 
-            total_series_cells = SigenergyCalculations._identify_battery_series_cells(
+            cells_per_module = SigenergyCalculations._identify_battery_series_cells(
                 pack_count_int, float(rated_capacity_kwh)
             )
 
-            if total_series_cells is None:
+            if cells_per_module is None:
                 _LOGGER.warning(
                     "[CS][ESS Current] Could not identify module type for %s: "
                     "%d packs, %.2f kWh rated capacity",
@@ -642,7 +647,7 @@ class SigenergyCalculations:
                 )
                 continue
 
-            system_voltage = total_series_cells * avg_cell_voltage
+            system_voltage = cells_per_module * avg_cell_voltage
             if system_voltage == 0:
                 continue
 

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -492,18 +492,6 @@ class SigenergyCalculations:
             "CS][Daily Batt Discharge"
         )
 
-    @staticmethod
-    def calculate_daily_battery_discharge_energy(
-        value,
-        coordinator_data: Optional[Dict[str, Any]] = None,
-        extra_params: Optional[Dict[str, Any]] = None,
-    ) -> Optional[Decimal]:
-        """Calculate the total daily battery discharge energy across all inverters."""
-        return SigenergyCalculations._calculate_total_inverter_energy(
-            coordinator_data,
-            "inverter_ess_daily_discharge_energy",
-            "CS][Daily Batt Discharge"
-        )
 
     @staticmethod
     def _identify_battery_series_cells(

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -585,6 +585,13 @@ class SigenergyCalculations:
                             + d * MODULE_TYPES[3][1]
                         )
 
+        # Divide by pack_count to get cells per module, not total cells.
+        # SigenStor modules connect in parallel — each has a built-in DC-DC
+        # optimiser so parallel stacking adds capacity while keeping voltage
+        # constant. system_voltage = cells_per_module × avg_cell_voltage
+        # regardless of how many modules are installed.
+        # Source: https://www.sigenergy.com/en/products/sigenstor
+        #         https://www.sigenergy.com/uploads/en_download/1693548782125366.pdf
         return best_cells // pack_count if best_cells is not None else None
 
     @staticmethod

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -1936,7 +1936,7 @@ class SigenergyCalculatedSensors:
         ),
         SigenergySensorEntityDescription(
             key="inverter_ess_current",
-            name="Battery Current (Calculated)",
+            name="Battery Current (Estimated)",
             device_class=SensorDeviceClass.CURRENT,
             native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
             state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     EntityCategory,
     UnitOfPower,
+    UnitOfElectricCurrent,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
@@ -491,6 +492,117 @@ class SigenergyCalculations:
             "CS][Daily Batt Discharge"
         )
 
+@staticmethod
+    def _identify_battery_series_cells(
+        pack_count: int,
+        rated_capacity_kwh: float,
+        tolerance: float = 0.02,
+    ) -> Optional[int]:
+        """Determine total cells in series across the battery stack.
+
+        Finds the combination of Sigenergy module types that matches the
+        given pack count and rated capacity, then returns the total number
+        of series-connected cells across all packs.
+
+        Module types (cells_in_series x cell_Ah):
+            5kWh  = 5.38kWh, 6 cells in series
+            6kWh  = 6.02kWh, 6 cells in series
+            8kWh  = 8.06kWh, 9 cells in series
+            10kWh = 9.04kWh, 9 cells in series
+
+        Args:
+            pack_count:         Number of battery packs (register 31024)
+            rated_capacity_kwh: Total rated battery capacity in kWh (register 30548)
+            tolerance:          Fractional tolerance for capacity matching (default 2%)
+
+        Returns:
+            Total cells in series, or None if no valid combination found.
+        """
+        # (capacity_kwh, cells_in_series)
+        MODULE_TYPES = [
+            (5.38, 6),   # 5kWh module
+            (6.02, 6),   # 6kWh module
+            (8.06, 9),   # 8kWh module
+            (9.04, 9),   # 10kWh module
+        ]
+        tolerance_kwh = rated_capacity_kwh * tolerance
+
+        for a in range(pack_count + 1):
+            for b in range(pack_count + 1 - a):
+                for c in range(pack_count + 1 - a - b):
+                    d = pack_count - a - b - c
+                    calc_capacity = (
+                        a * MODULE_TYPES[0][0]
+                        + b * MODULE_TYPES[1][0]
+                        + c * MODULE_TYPES[2][0]
+                        + d * MODULE_TYPES[3][0]
+                    )
+                    if abs(calc_capacity - rated_capacity_kwh) <= tolerance_kwh:
+                        return (
+                            a * MODULE_TYPES[0][1]
+                            + b * MODULE_TYPES[1][1]
+                            + c * MODULE_TYPES[2][1]
+                            + d * MODULE_TYPES[3][1]
+                        )
+        return None
+
+    @staticmethod
+    def calculate_ess_current(
+        _,
+        coordinator_data: Optional[Dict[str, Any]] = None,
+        extra_params: Optional[Dict[str, Any]] = None,
+    ) -> Optional[float]:
+        """Calculate ESS current (A) from power, pack configuration and live
+        average cell voltage.
+
+        Uses pack count and rated capacity to identify the battery module
+        combination, determines total series cells, then divides power by
+        the live system voltage (series_cells × avg_cell_voltage).
+
+        Positive = charging, negative = discharging.
+        Returns None if data is unavailable or module type cannot be identified.
+        """
+        if not coordinator_data or not extra_params:
+            return None
+
+        device_name = extra_params.get("device_name")
+        inverter_data = coordinator_data.get("inverters", {}).get(device_name, {})
+
+        ess_power_kw       = safe_float(inverter_data.get("inverter_ess_charge_discharge_power"))
+        avg_cell_voltage   = safe_float(inverter_data.get("inverter_ess_average_cell_voltage"))
+        pack_count         = inverter_data.get("inverter_pack_count")
+        rated_capacity_kwh = safe_float(inverter_data.get("inverter_rated_battery_capacity"))
+
+        if any(v is None for v in [ess_power_kw, avg_cell_voltage,
+                                    pack_count, rated_capacity_kwh]):
+            _LOGGER.debug(
+                "[CS][ESS Current] Missing data for %s: power=%s, cell_v=%s, packs=%s, capacity=%s",
+                device_name, ess_power_kw, avg_cell_voltage, pack_count, rated_capacity_kwh,
+            )
+            return None
+
+        pack_count_int = int(pack_count)
+        if pack_count_int == 0 or avg_cell_voltage == 0:
+            return None
+
+        total_series_cells = SigenergyCalculations._identify_battery_series_cells(
+            pack_count_int, float(rated_capacity_kwh)
+        )
+
+        if total_series_cells is None:
+            _LOGGER.warning(
+                "[CS][ESS Current] Could not identify module type for %s: "
+                "%d packs, %.2f kWh rated capacity",
+                device_name, pack_count_int, rated_capacity_kwh,
+            )
+            return None
+
+        system_voltage = total_series_cells * avg_cell_voltage
+        if system_voltage == 0:
+            return None
+
+        return round((ess_power_kw * 1000) / system_voltage, 2)
+    
     @staticmethod
     def calculate_plant_daily_pv_energy(
         value,
@@ -1775,6 +1887,17 @@ class SigenergyCalculatedSensors:
             ),
             extra_fn_data=True,  # Indicates that this sensor needs coordinator data
             entity_registry_enabled_default=False,
+        ),
+        SigenergySensorEntityDescription(
+            key="inverter_ess_current",
+            name="Battery Current",
+            device_class=SensorDeviceClass.CURRENT,
+            native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=2,
+            icon="mdi:current-dc",
+            value_fn=SigenergyCalculations.calculate_ess_current,
+            extra_fn_data=True,
         ),
     ]
 

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -486,31 +486,66 @@ class SigenergyCalculations:
     ) -> Optional[int]:
         """Determine total cells in series across the battery stack.
 
-        Finds the combination of Sigenergy module types that matches the
-        given pack count and rated capacity, then returns the total number
-        of series-connected cells across all packs.
+        Finds the combination of Sigenergy module types that best matches
+        the given pack count and rated capacity, then returns the total
+        number of series-connected cells across all packs.
 
-        Module types (cells_in_series x cell_Ah):
-            5kWh  = 5.38kWh, 6 cells in series
-            6kWh  = 6.02kWh, 6 cells in series
-            8kWh  = 8.06kWh, 9 cells in series
-            10kWh = 9.04kWh, 9 cells in series
+        The search is exhaustive over all valid combinations of module types
+        that sum to pack_count, and returns the combination whose total
+        capacity is closest to rated_capacity_kwh (within tolerance).
+
+        Module types:
+            5kWh  = 5.38 kWh, 6 cells in series
+            6kWh  = 6.02 kWh, 6 cells in series
+            8kWh  = 8.06 kWh, 9 cells in series
+            10kWh = 9.04 kWh, 9 cells in series
+
+        pack_count is taken directly from register 31024
+        (inverter_pack_count) and reflects the actual number of modules
+        installed in the battery stack on that inverter. The sanity cap
+        exists only to guard against corrupt register values — it is set
+        well above any currently documented Sigenergy hardware limit.
 
         Args:
-            pack_count:         Number of battery packs (register 31024)
-            rated_capacity_kwh: Total rated battery capacity in kWh (register 30548)
-            tolerance:          Fractional tolerance for capacity matching (default 2%)
+            pack_count:         Number of battery packs from register 31024.
+            rated_capacity_kwh: Total rated battery capacity in kWh from
+                                register 30548.
+            tolerance:          Fractional tolerance for capacity matching
+                                (default 2 %).
 
         Returns:
-            Total cells in series, or None if no valid combination found.
+            Total cells in series for the best-matching combination, or
+            None if no combination falls within the tolerance window.
         """
+        # Sanity cap: guards against corrupt register values only.
+        # The real constraint is the value of inverter_pack_count itself.
+        # Set to 20 to accommodate any future Sigenergy hardware expansion
+        # well beyond the current documented maximum of 6 per stack.
+        SANITY_CAP = 20
+
+        # (capacity_kwh, cells_in_series)
         MODULE_TYPES = [
-            (5.38, 6),   # 5kWh module
-            (6.02, 6),   # 6kWh module
-            (8.06, 9),   # 8kWh module
-            (9.04, 9),   # 10kWh module
+            (5.38, 6),   # 5 kWh module
+            (6.02, 6),   # 6 kWh module
+            (8.06, 9),   # 8 kWh module
+            (9.04, 9),   # 10 kWh module
         ]
+
+        # Apply sanity cap — log a warning if it triggers so corrupt
+        # register values are visible rather than causing silent errors.
+        if pack_count > SANITY_CAP:
+            _LOGGER.warning(
+                "[CS][ESS Current] pack_count=%d exceeds sanity cap of %d. "
+                "This likely indicates a corrupt register value. "
+                "Capping at %d for safety.",
+                pack_count, SANITY_CAP, SANITY_CAP,
+            )
+            pack_count = SANITY_CAP
+
         tolerance_kwh = rated_capacity_kwh * tolerance
+
+        best_cells: Optional[int] = None
+        best_delta: float = float("inf")
 
         for a in range(pack_count + 1):
             for b in range(pack_count + 1 - a):
@@ -522,14 +557,17 @@ class SigenergyCalculations:
                         + c * MODULE_TYPES[2][0]
                         + d * MODULE_TYPES[3][0]
                     )
-                    if abs(calc_capacity - rated_capacity_kwh) <= tolerance_kwh:
-                        return (
+                    delta = abs(calc_capacity - rated_capacity_kwh)
+                    if delta <= tolerance_kwh and delta < best_delta:
+                        best_delta = delta
+                        best_cells = (
                             a * MODULE_TYPES[0][1]
                             + b * MODULE_TYPES[1][1]
                             + c * MODULE_TYPES[2][1]
                             + d * MODULE_TYPES[3][1]
                         )
-        return None
+
+        return best_cells
 
     @staticmethod
     def calculate_ess_current(

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -574,46 +574,60 @@ class SigenergyCalculations:
         Positive = charging, negative = discharging.
         Returns None if data is unavailable or module type cannot be identified.
         """
-        if not coordinator_data or not extra_params:
+        if not coordinator_data:
             return None
 
-        device_name = extra_params.get("device_name")
-        inverter_data = coordinator_data.get("inverters", {}).get(device_name, {})
+        # Try extra_params device_name first, then fall back to iterating inverters.
+        # extra_params["device_name"] may not be populated for inverter-level
+        # calculated sensors, so we iterate and return the first valid result.
+        inverters_data = coordinator_data.get("inverters", {})
+        if not inverters_data:
+            _LOGGER.debug("[CS][ESS Current] No inverter data in coordinator")
+            return None
 
-        ess_power_kw       = safe_float(inverter_data.get("inverter_ess_charge_discharge_power"))
-        avg_cell_voltage   = safe_float(inverter_data.get("inverter_ess_average_cell_voltage"))
-        pack_count         = inverter_data.get("inverter_pack_count")
-        rated_capacity_kwh = safe_float(inverter_data.get("inverter_rated_battery_capacity"))
+        device_name = (extra_params or {}).get("device_name")
+        if device_name and device_name in inverters_data:
+            candidates = {device_name: inverters_data[device_name]}
+        else:
+            candidates = inverters_data
 
-        if any(v is None for v in [ess_power_kw, avg_cell_voltage,
-                                    pack_count, rated_capacity_kwh]):
-            _LOGGER.debug(
-                "[CS][ESS Current] Missing data for %s: power=%s, cell_v=%s, packs=%s, capacity=%s",
-                device_name, ess_power_kw, avg_cell_voltage, pack_count, rated_capacity_kwh,
+        for inv_name, inverter_data in candidates.items():
+            ess_power_kw       = safe_float(inverter_data.get("inverter_ess_charge_discharge_power"))
+            avg_cell_voltage   = safe_float(inverter_data.get("inverter_ess_average_cell_voltage"))
+            pack_count         = inverter_data.get("inverter_pack_count")
+            rated_capacity_kwh = safe_float(inverter_data.get("inverter_rated_battery_capacity"))
+
+            if any(v is None for v in [ess_power_kw, avg_cell_voltage,
+                                        pack_count, rated_capacity_kwh]):
+                _LOGGER.debug(
+                    "[CS][ESS Current] Missing data for %s: power=%s, cell_v=%s, packs=%s, capacity=%s",
+                    inv_name, ess_power_kw, avg_cell_voltage, pack_count, rated_capacity_kwh,
+                )
+                continue
+
+            pack_count_int = int(pack_count)
+            if pack_count_int == 0 or avg_cell_voltage == 0:
+                continue
+
+            total_series_cells = SigenergyCalculations._identify_battery_series_cells(
+                pack_count_int, float(rated_capacity_kwh)
             )
-            return None
 
-        pack_count_int = int(pack_count)
-        if pack_count_int == 0 or avg_cell_voltage == 0:
-            return None
+            if total_series_cells is None:
+                _LOGGER.warning(
+                    "[CS][ESS Current] Could not identify module type for %s: "
+                    "%d packs, %.2f kWh rated capacity",
+                    inv_name, pack_count_int, rated_capacity_kwh,
+                )
+                continue
 
-        total_series_cells = SigenergyCalculations._identify_battery_series_cells(
-            pack_count_int, float(rated_capacity_kwh)
-        )
+            system_voltage = total_series_cells * avg_cell_voltage
+            if system_voltage == 0:
+                continue
 
-        if total_series_cells is None:
-            _LOGGER.warning(
-                "[CS][ESS Current] Could not identify module type for %s: "
-                "%d packs, %.2f kWh rated capacity",
-                device_name, pack_count_int, rated_capacity_kwh,
-            )
-            return None
+            return round((ess_power_kw * 1000) / system_voltage, 2)
 
-        system_voltage = total_series_cells * avg_cell_voltage
-        if system_voltage == 0:
-            return None
-
-        return round((ess_power_kw * 1000) / system_voltage, 2)
+        return None
 
     @staticmethod
     def calculate_plant_daily_pv_energy(

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -1926,7 +1926,7 @@ class SigenergyCalculatedSensors:
         ),
         SigenergySensorEntityDescription(
             key="inverter_ess_current",
-            name="Battery Current",
+            name="Battery Current (Calculated)",
             device_class=SensorDeviceClass.CURRENT,
             native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
             state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -479,6 +479,19 @@ class SigenergyCalculations:
         )
 
     @staticmethod
+    def calculate_daily_battery_discharge_energy(
+        value,
+        coordinator_data: Optional[Dict[str, Any]] = None,
+        extra_params: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Decimal]:
+        """Calculate the total daily battery discharge energy across all inverters."""
+        return SigenergyCalculations._calculate_total_inverter_energy(
+            coordinator_data,
+            "inverter_ess_daily_discharge_energy",
+            "CS][Daily Batt Discharge"
+        )
+
+    @staticmethod
     def _identify_battery_series_cells(
         pack_count: int,
         rated_capacity_kwh: float,
@@ -588,9 +601,6 @@ class SigenergyCalculations:
         if not coordinator_data:
             return None
 
-        # Try extra_params device_name first, then fall back to iterating inverters.
-        # extra_params["device_name"] may not be populated for inverter-level
-        # calculated sensors, so we iterate and return the first valid result.
         inverters_data = coordinator_data.get("inverters", {})
         if not inverters_data:
             _LOGGER.debug("[CS][ESS Current] No inverter data in coordinator")

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -627,7 +627,7 @@ class SigenergyCalculations:
                 continue
 
             pack_count_int = int(pack_count)
-            if pack_count_int == 0 or avg_cell_voltage == 0:
+            if pack_count_int == 0 or avg_cell_voltage == 0 or not rated_capacity_kwh:
                 continue
 
             total_series_cells = SigenergyCalculations._identify_battery_series_cells(

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -479,21 +479,6 @@ class SigenergyCalculations:
         )
 
     @staticmethod
-    def calculate_daily_battery_discharge_energy(
-        value,
-        coordinator_data: Optional[Dict[str, Any]] = None,
-        extra_params: Optional[Dict[str, Any]] = None,
-    ) -> Optional[Decimal]:
-        """Calculate the total daily battery discharge energy across all inverters."""
-        # _LOGGER.debug("[CS][Daily Batt Discharge] Calculating daily battery discharge energy")
-        return SigenergyCalculations._calculate_total_inverter_energy(
-            coordinator_data,
-            "inverter_ess_daily_discharge_energy",
-            "CS][Daily Batt Discharge"
-        )
-
-
-    @staticmethod
     def _identify_battery_series_cells(
         pack_count: int,
         rated_capacity_kwh: float,

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -241,7 +241,7 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
             try:
                 # Call transformation function, trying 3,2,1 args for compatibility
                 fn = self.entity_description.value_fn
-                extra_params = getattr(self.entity_description, "extra_params", {}) or {}
+                extra_params = {**(getattr(self.entity_description, "extra_params", {}) or {}), "device_name": self._device_name}
                 transformed = None
                 for args in [(raw_value, data, extra_params), (raw_value, data), (raw_value,)]:
                     try:


### PR DESCRIPTION
As there is no published register this calculated sensor provided a Battery Current (A) sensor for the SigenStor battery.
This is calculated taking into account the number of modules in the stack and the rated capacity of the battery, with logic applied from this based upon the 5/6/8/10kWh battery modules and their usable energy capacity.

Given this, in the Inverter device settings of HA, the Pack Count and Rated Battery Capacity sensors must be enabled:

<img width="332" height="212" alt="image" src="https://github.com/user-attachments/assets/f7c7a14f-dd9b-4cae-9ef7-494c41596d87" />

After updating and rebooting the Inverter Sensors will have the following added:

<img width="332" height="240" alt="image" src="https://github.com/user-attachments/assets/85fc8d5d-b2cf-43e8-bf58-5086fc29f76b" />

As I only have a single SigenStor, not exactly sure for adding this per battery, then (I'd assume) having an average of all batteries current sensors, that is published in the Plant device as a sensor.sigen_plant_battery_current ?