### PR TITLE
Fix zero-bounce phantom energy spikes on Modbus reconnection

### DIFF
--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -404,6 +404,7 @@ class SigenergyCalculations:
             return None
 
         total_energy = Decimal("0.0")
+        valid_sample_count = 0
         inverters_data = coordinator_data.get("inverters", {})
 
         if not inverters_data:
@@ -411,10 +412,20 @@ class SigenergyCalculations:
             return None # No inverters found
 
         for inverter_name, inverter_data in inverters_data.items():
-            energy_value = safe_decimal(inverter_data.get(energy_key))
+            raw = inverter_data.get(energy_key)
+            if raw is None:
+                _LOGGER.debug(
+                    "[%s] Missing '%s' for inverter %s",
+                    log_prefix,
+                    energy_key,
+                    inverter_name,
+                )
+                continue
+            energy_value = safe_decimal(raw)
             if energy_value is not None:
                 try:
                     total_energy += energy_value
+                    valid_sample_count += 1
                 except (ValueError, TypeError, InvalidOperation) as e:
                     _LOGGER.warning(
                         "[%s] Invalid energy value '%s' for key '%s' in inverter %s: %s",
@@ -426,11 +437,16 @@ class SigenergyCalculations:
                     )
             else:
                 _LOGGER.debug(
-                    "[%s] Missing '%s' for inverter %s",
+                    "[%s] Could not convert '%s' for inverter %s",
                     log_prefix,
-                    energy_key,
-                    inverter_name
-                 )
+                    raw,
+                    inverter_name,
+                )
+
+        # All inverters offline/missing → report unavailable, not 0
+        if valid_sample_count == 0:
+            _LOGGER.debug("[%s] No valid samples for '%s', returning None", log_prefix, energy_key)
+            return None
 
         # Return as Decimal, matching other calculated sensors
         return safe_decimal(total_energy)

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, Optional, cast
 from decimal import Decimal, InvalidOperation
 
@@ -19,6 +19,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -220,9 +221,13 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
         self._last_valid_daily_energy_value: Decimal | None = None
 
     def _is_near_daily_reset(self) -> bool:
-        """Return True if within ±20 minutes of midnight (legitimate daily reset window)."""
-        now = datetime.now()
-        seconds_since_midnight = (now - now.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds()
+        """Return True if within ±20 minutes of midnight (legitimate daily reset window).
+
+        Uses dt_util.now() so the check respects HA's configured timezone, not the OS clock.
+        """
+        now = dt_util.now()
+        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        seconds_since_midnight = (now - midnight).total_seconds()
         window = _DAILY_RESET_WINDOW.total_seconds()
         return seconds_since_midnight <= window or seconds_since_midnight >= 86400 - window
 

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import logging
+from datetime import datetime, timedelta
 from typing import Any, Optional, cast
 from decimal import Decimal, InvalidOperation
 
@@ -48,6 +49,21 @@ from .const import (
 from .sigen_entity import SigenergyEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+# Daily energy sensor keys where a transient zero during reconnection should be
+# suppressed (reported as unavailable) rather than accepted as valid data.
+# These sensors use TOTAL_INCREASING, so a false zero causes phantom energy spikes.
+_PROTECTED_DAILY_ENERGY_KEYS = frozenset({
+    "plant_daily_pv_energy",
+    "plant_daily_battery_charge_energy",
+    "plant_daily_battery_discharge_energy",
+    "inverter_daily_pv_energy",
+    "inverter_ess_daily_charge_energy",
+    "inverter_ess_daily_discharge_energy",
+})
+
+# Legitimate midnight resets are allowed within ±20 minutes of 00:00.
+_DAILY_RESET_WINDOW = timedelta(minutes=20)
 
 
 async def async_setup_entry(
@@ -201,6 +217,41 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
             if isinstance(description, SigenergySensorEntityDescription)
             else None
         )
+        self._last_valid_daily_energy_value: Decimal | None = None
+
+    def _is_near_daily_reset(self) -> bool:
+        """Return True if within ±20 minutes of midnight (legitimate daily reset window)."""
+        now = datetime.now()
+        seconds_since_midnight = (now - now.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds()
+        window = _DAILY_RESET_WINDOW.total_seconds()
+        return seconds_since_midnight <= window or seconds_since_midnight >= 86400 - window
+
+    def _apply_daily_energy_zero_guard(self, value: Any) -> Any:
+        """Suppress transient zero drops for daily energy sensors outside the midnight window.
+
+        When a Modbus reconnection causes the inverter to briefly report 0 for a daily
+        energy counter, this converts that 0 to None (unavailable) so HA's TOTAL_INCREASING
+        handling does not interpret the recovery as new phantom production.
+        """
+        if self.entity_description.key not in _PROTECTED_DAILY_ENERGY_KEYS:
+            return value
+        if value is None:
+            return value
+        try:
+            decimal_value = Decimal(str(value))
+        except (ValueError, TypeError, InvalidOperation):
+            return value
+        last = self._last_valid_daily_energy_value
+        if decimal_value == 0 and last is not None and last > 0 and not self._is_near_daily_reset():
+            _LOGGER.debug(
+                "[%s] Suppressing transient zero (last valid: %s) outside midnight window",
+                self.entity_id,
+                last,
+            )
+            return None
+        if decimal_value > 0:
+            self._last_valid_daily_energy_value = decimal_value
+        return value
 
     def _decode_alarm_bits(self, value: int, alarm_mapping: dict) -> str:
         """Decode alarm bits into human-readable text."""
@@ -252,8 +303,8 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
 
                 # Round if needed
                 if transformed is not None and self._round_digits is not None:
-                    return round(Decimal(transformed), self._round_digits)
-                return transformed
+                    return self._apply_daily_energy_zero_guard(round(Decimal(transformed), self._round_digits))
+                return self._apply_daily_energy_zero_guard(transformed)
             except Exception as ex:
                 if raw_value is None:
                     _LOGGER.debug("Value function failed for %s because data is missing: %s", self.entity_id, ex)
@@ -313,11 +364,11 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
 
         if self._round_digits is not None:
             try:
-                return round(Decimal(raw_value), self._round_digits)
+                return self._apply_daily_energy_zero_guard(round(Decimal(raw_value), self._round_digits))
             except (TypeError, ValueError, InvalidOperation):
                 _LOGGER.warning("Could not round direct value for %s: %s", self.entity_id, raw_value)
 
-        return raw_value
+        return self._apply_daily_energy_zero_guard(raw_value)
 
 
 class PVStringSensor(SigenergySensor):


### PR DESCRIPTION
Fixes #313

## Summary

After a HA restart or Modbus disruption the inverter briefly reports `0` for daily energy registers. Because these sensors use `TOTAL_INCREASING`, HA interprets the `30 kWh → 0 kWh → 30 kWh` bounce as a reset followed by new production, injecting phantom kWh into the Energy Dashboard.

Two targeted, non-breaking fixes across two files.

## Changes

### `calculated_sensor.py` — `_calculate_total_inverter_energy()`
- Tracks `valid_sample_count` across the inverter loop
- Returns `None` (unavailable) instead of `Decimal("0")` when every inverter returns `None` (all-offline scenario)
- Fixes: `plant_daily_pv_energy`, `plant_daily_battery_charge_energy`, `plant_daily_battery_discharge_energy`

### `sensor.py` — `SigenergySensor`
- Adds `_apply_daily_energy_zero_guard()`: converts a transient zero to `None` (unavailable) when the previous valid value was positive and the clock is outside a ±20-minute midnight window
- Fixes: `inverter_daily_pv_energy`, `inverter_ess_daily_charge_energy`, `inverter_ess_daily_discharge_energy`

## Why non-breaking
- No config schema changes, no entity ID renames, no removed functionality
- HA Energy Dashboard already treats `unavailable` as a gap
- Legitimate midnight resets pass through the ±20-minute window

## Test plan
- [ ] Block Modbus port briefly; confirm affected sensors show `unavailable` not `0.0`
- [ ] Confirm no phantom energy spike in Energy Dashboard after reconnection
- [ ] At 00:01, confirm sensors show expected small post-midnight value
- [ ] Confirm unprotected sensors are unaffected