### PR TITLE
[codex] Fix daily energy reset handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ Plant (IP:Port)
 > [!NOTE]
 > Controls are **read-only by default** unless  explicitly enabled in the integration configuration.
 
+## Known Limitations & Important Notes
+
+- **Sigenergy "Grid side info" is not fully available over local Modbus.** The grid-side details shown in the Sigen app are not currently exposed through a stable Modbus register set. Some diagnostic grid phase voltage/current sensors added in `v1.2.2` can remain unavailable if the device rejects those registers. This has been reported on single-phase firmware `V100R001C22SPC113`; see [discussion #295](https://github.com/TypQxQ/Sigenergy-Local-Modbus/discussions/295#discussioncomment-16776425).
+- **Grid phase voltage/current support depends on Sigenergy firmware and Modbus documentation.** The gateway/grid phase registers were included in at least one `V2.8` Modbus protocol document and were discussed in [discussion #192](https://github.com/TypQxQ/Sigenergy-Local-Modbus/discussions/192), but not all `V2.8` documents match. In the local `Modbus_Protocol_EN_2.8-SIGEN.pdf` copy used by this project, `V2.8` is dated `2025-11-28` and the plant running info table lists new registers up to `30284` (`General load power` and `Total load power`). It does not list the grid phase voltage/current registers currently mapped at `30286`, `30288`, `30290`, `30292`, `30294`, and `30296`, so these sensors may not work even on newer firmware.
+- **`Register validation failed ... exception_code=2` usually means an unsupported register.** If you see this in debug logs for addresses such as `30286`, `30288`, `30290`, `30292`, `30294`, or `30296`, the integration is likely skipping grid-side registers your device does not expose, not failing the whole integration. Address `30281` is `Merged Alarm7` in the `2025-11-28` V2.8 document and may also be unsupported if your firmware does not expose the newer V2.8 plant registers.
+- **Controls and diagnostic entities are conservative by default.** Write controls and many diagnostic sensors are disabled by default. To use controls, disable read-only mode in the integration options and enable the specific entity in Home Assistant only if you understand the setting.
+- **Device IDs and topology matter.** AC chargers are normally device ID `1`; inverters must use another ID. DC charger data is read via the inverter, and all devices in a plant should normally use the same host and port.
+
 ## Quickstart Automation Example
 ```yaml
 alias: "Notify on Low Battery"

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -646,8 +646,12 @@ class SigenergyCalculations:
             pack_count         = inverter_data.get("inverter_pack_count")
             rated_capacity_kwh = safe_float(inverter_data.get("inverter_rated_battery_capacity"))
 
-            if any(v is None for v in [ess_power_kw, avg_cell_voltage,
-                                        pack_count, rated_capacity_kwh]):
+            if (
+                ess_power_kw is None
+                or avg_cell_voltage is None
+                or pack_count is None
+                or rated_capacity_kwh is None
+            ):
                 _LOGGER.debug(
                     "[CS][ESS Current] Missing data for %s: power=%s, cell_v=%s, packs=%s, capacity=%s",
                     inv_name, ess_power_kw, avg_cell_voltage, pack_count, rated_capacity_kwh,

--- a/custom_components/sigen/manifest.json
+++ b/custom_components/sigen/manifest.json
@@ -31,5 +31,5 @@
   "requirements": [
     "pymodbus>=3.8.3"
   ],
-  "version": "1.2.0"
+  "version": "1.2.3"
 }

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 import logging
-from datetime import timedelta
+from datetime import date, timedelta
 from typing import Any, Optional, cast
 from decimal import Decimal, InvalidOperation
 
@@ -219,7 +219,7 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
             else None
         )
         self._last_valid_daily_energy_value: Decimal | None = None
-        self._last_valid_daily_energy_date = None
+        self._last_valid_daily_energy_date: date | None = None
 
     def _is_near_daily_reset(self) -> bool:
         """Return True if within ±20 minutes of midnight (legitimate daily reset window).

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -37,7 +37,7 @@ from .calculated_sensor import (
 )
 from .static_sensor import StaticSensors as SS
 from .static_sensor import COORDINATOR_DIAGNOSTIC_SENSORS # Import the new descriptions
-from .common import generate_sigen_entity, generate_device_id, SigenergySensorEntityDescription, SensorEntityDescription
+from .common import generate_sigen_entity, generate_device_id, SigenergySensorEntityDescription
 from .const import (
     DOMAIN,
     DEVICE_TYPE_PLANT,
@@ -247,13 +247,17 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
         except (ValueError, TypeError, InvalidOperation):
             return value
         last = self._last_valid_daily_energy_value
-        if decimal_value == 0 and last is not None and last > 0 and not self._is_near_daily_reset():
-            _LOGGER.debug(
-                "[%s] Suppressing transient zero (last valid: %s) outside midnight window",
-                self.entity_id,
-                last,
-            )
-            return None
+        if decimal_value == 0:
+            if self._is_near_daily_reset():
+                self._last_valid_daily_energy_value = decimal_value
+                return value
+            if last is not None and last > 0:
+                _LOGGER.debug(
+                    "[%s] Suppressing transient zero (last valid: %s) outside midnight window",
+                    self.entity_id,
+                    last,
+                )
+                return None
         if decimal_value > 0:
             self._last_valid_daily_energy_value = decimal_value
         return value

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -219,6 +219,7 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
             else None
         )
         self._last_valid_daily_energy_value: Decimal | None = None
+        self._last_valid_daily_energy_date = None
 
     def _is_near_daily_reset(self) -> bool:
         """Return True if within ±20 minutes of midnight (legitimate daily reset window).
@@ -247,9 +248,12 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
         except (ValueError, TypeError, InvalidOperation):
             return value
         last = self._last_valid_daily_energy_value
+        today = dt_util.now().date()
+        last_date = self._last_valid_daily_energy_date
         if decimal_value == 0:
-            if self._is_near_daily_reset():
+            if self._is_near_daily_reset() or (last_date is not None and last_date < today):
                 self._last_valid_daily_energy_value = decimal_value
+                self._last_valid_daily_energy_date = today
                 return value
             if last is not None and last > 0:
                 _LOGGER.debug(
@@ -260,6 +264,7 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
                 return None
         if decimal_value > 0:
             self._last_valid_daily_energy_value = decimal_value
+            self._last_valid_daily_energy_date = today
         return value
 
     def _decode_alarm_bits(self, value: int, alarm_mapping: dict) -> str:

--- a/todo.md
+++ b/todo.md
@@ -1,40 +1,7 @@
-- Checks for duplicates
-- Check if dc_charger_start_stop is getting right state. running state?
-- Recheck availability all sensors each 360th check. This is 30 min whith default interval of 5s.
+# TODO
 
+No current TODO entries are tracked in this file.
 
-# Changes in 2.7
-
-# This are missing yet:
-- plant_pv_daily_total_generation 
-
-# This have been added:
-- plant_total_generation_of_third_party_inverter
-- plant_smart_load_XX_power ( where XX is 1 - 24 )
-- plant_smart_load_XX_total_consumption ( where XX is 1 - 24 )
-- plant_total_discharged_energy_of_the_evdc
-- plant_total_charged_energy_of_the_evdc
-- plant_total_generation_of_self_pv
-- plant_total_charged_energy_of_the_evac
-- plant_total_energy_output_of_oil_fueled_generator
-- inverter_power_factor_adjustment_feedback
-- inverter_reactive_power_qs_adjustment_feedback
-- inverter_active_power_percentage_adjustment_feedback
-- inverter_reactive_power_fixed_value_adjustment_feedback
-- inverter_active_power_fixed_value_adjustment_feedback
-
-# This sensors have moved from calculated to static sensors, regaining history
-- plant_accumulated_battery_charge_energy
-- plant_accumulated_battery_discharge_energy
-- plant_accumulated_consumed_energy
-- plant_daily_consumed_energy
-- plant_accumulated_pv_energy
-- plant_accumulated_grid_export_energy
-- plant_accumulated_grid_import_energy
-- inverter_accumulated_pv_energy
-- inverter_daily_pv_energy
-
-# Configurable values added:
-- plant_discharge_cut_off_soc
-- plant_charge_cut_off_soc
-- plant_backup_soc
+Outdated historical entries were removed because this file had not been
+maintained across recent releases. Before adding new items, verify them against
+the current code, documentation, and GitHub issues or discussions.


### PR DESCRIPTION
## Summary
- Fix daily energy zero handling so legitimate post-midnight zero values remain available until production/activity starts.
- Add README notes for grid-side Modbus limitations and conflicting V2.8 register documentation.
- Clear stale historical entries from todo.md.
- Clean up pyright type issues in calculated/sensor code.

## Root cause
The daily energy zero guard remembered yesterday's positive value. After the midnight grace window elapsed, normal overnight zeros were treated as transient Modbus zero drops and returned as unavailable.

## Validation
- python -m compileall -q custom_components\sigen
- npx --yes pyright
