### PR TITLE
[codex] Add AC charger start and stop buttons

### DIFF
--- a/custom_components/sigen/button.py
+++ b/custom_components/sigen/button.py
@@ -9,11 +9,13 @@ from homeassistant.components.button import ButtonEntity, ButtonEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .common import generate_sigen_entity
+from .common import ac_charger_command_available, generate_sigen_entity
 from .const import (
+    DEVICE_TYPE_AC_CHARGER,
     DEVICE_TYPE_PLANT,
     DOMAIN,
 )
@@ -29,6 +31,7 @@ class SigenergyButtonEntityDescription(ButtonEntityDescription):
     press_fn: Callable[[SigenergyDataUpdateCoordinator, Optional[Any]], Coroutine[Any, Any, None]] = lambda coordinator, identifier: asyncio.sleep(0)
     available_fn: Callable[[Dict[str, Any], Optional[Any]], bool] = lambda data, _: True
 
+
 PLANT_BUTTONS: list[SigenergyButtonEntityDescription] = [
     SigenergyButtonEntityDescription(
         key="plant_grid_power_loss_lockout_alarm_clear",
@@ -36,6 +39,23 @@ PLANT_BUTTONS: list[SigenergyButtonEntityDescription] = [
         icon="mdi:alarm-check",
         press_fn=lambda coordinator, _: coordinator.async_write_parameter("plant", None, "plant_grid_power_loss_lockout_alarm_clear", 1),
         entity_category=EntityCategory.CONFIG,
+    ),
+]
+
+AC_CHARGER_BUTTONS: list[SigenergyButtonEntityDescription] = [
+    SigenergyButtonEntityDescription(
+        key="ac_charger_start",
+        name="Start Charging",
+        icon="mdi:ev-plug-type2",
+        press_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 0),
+        available_fn=ac_charger_command_available,
+    ),
+    SigenergyButtonEntityDescription(
+        key="ac_charger_stop",
+        name="Stop Charging",
+        icon="mdi:ev-plug-type2-off",
+        press_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 1),
+        available_fn=ac_charger_command_available,
     ),
 ]
 
@@ -57,6 +77,19 @@ async def async_setup_entry(
         PLANT_BUTTONS,
         DEVICE_TYPE_PLANT,
     )
+
+    for device_name, device_conn in coordinator.hub.ac_charger_connections.items():
+        entities.extend(
+            generate_sigen_entity(
+                plant_name,
+                device_name,
+                device_conn,
+                coordinator,
+                SigenergyButton,
+                AC_CHARGER_BUTTONS,
+                DEVICE_TYPE_AC_CHARGER,
+            )
+        )
 
     if entities:
         async_add_entities(entities)
@@ -101,5 +134,7 @@ class SigenergyButton(SigenergyEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
+        if self.coordinator.data is None:
+            raise HomeAssistantError(f"Cannot press {self.entity_id}: Coordinator data is unavailable")
         identifier = self._device_name
         await self.entity_description.press_fn(self.coordinator, identifier)

--- a/custom_components/sigen/common.py
+++ b/custom_components/sigen/common.py
@@ -18,6 +18,12 @@ from .const import (DOMAIN, DEVICE_TYPE_INVERTER, DEVICE_TYPE_DC_CHARGER)
 _LOGGER = logging.getLogger(__name__)
 
 
+def ac_charger_command_available(data: Dict[str, Any], identifier: Optional[Any]) -> bool:
+    """Return if AC charger start/stop commands should be exposed."""
+    state = data.get("ac_chargers", {}).get(identifier, {}).get("ac_charger_system_state")
+    return state is not None and state not in (0, 1)
+
+
 def get_suffix_if_not_one(name: str) -> str:
     """Get the last part of the name if it is a number other than 1."""
     return name.split()[-1].strip() + " " if len(name.split()) > 1 and name.split()[-1].isdigit() and name.split()[-1] != "1" else ""

--- a/custom_components/sigen/switch.py
+++ b/custom_components/sigen/switch.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.exceptions import HomeAssistantError
 
-from .common import ac_charger_command_available, generate_sigen_entity, generate_device_id
+from .common import generate_sigen_entity, generate_device_id
 from .const import (
     DEVICE_TYPE_AC_CHARGER,
     DEVICE_TYPE_DC_CHARGER,
@@ -41,6 +41,11 @@ class SigenergySwitchEntityDescription(SwitchEntityDescription):
     turn_off_fn: Callable[[SigenergyDataUpdateCoordinator, Optional[Any]], Coroutine[Any, Any, None]] = lambda coordinator, identifier: asyncio.sleep(0) # Placeholder async lambda
     available_fn: Callable[[Dict[str, Any], Optional[Any]], bool] = lambda data, _: True
     entity_registry_enabled_default: bool = True
+
+
+def _deprecated_ac_charger_switch_available(data: Dict[str, Any], identifier: Optional[Any]) -> bool:
+    """Preserve legacy switch availability when charger state is missing."""
+    return data.get("ac_chargers", {}).get(identifier, {}).get("ac_charger_system_state") not in (0, 1)
 
 
 PLANT_SWITCHES: list[SigenergySwitchEntityDescription] = [
@@ -113,7 +118,7 @@ AC_CHARGER_SWITCHES: list[SigenergySwitchEntityDescription] = [
         # identifier here will be ac_charger_name
         is_on_fn=lambda data, identifier: data.get("ac_chargers", {}).get(identifier, {}).get("ac_charger_system_state") in (2,3,4,5),
         # Check if EV is connected (State != 0 (Init) and != 1 (A1_A2))
-        available_fn=ac_charger_command_available,
+        available_fn=_deprecated_ac_charger_switch_available,
         turn_on_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 0),
         turn_off_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 1),
         entity_registry_enabled_default=False,

--- a/custom_components/sigen/switch.py
+++ b/custom_components/sigen/switch.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.exceptions import HomeAssistantError
 
-from .common import generate_sigen_entity, generate_device_id
+from .common import ac_charger_command_available, generate_sigen_entity, generate_device_id
 from .const import (
     DEVICE_TYPE_AC_CHARGER,
     DEVICE_TYPE_DC_CHARGER,
@@ -108,14 +108,15 @@ INVERTER_SWITCHES: list[SigenergySwitchEntityDescription] = [
 AC_CHARGER_SWITCHES: list[SigenergySwitchEntityDescription] = [
     SigenergySwitchEntityDescription(
         key="ac_charger_start_stop",
-        name="AC Charger Power",
+        name="AC Charger Power (Deprecated)",
         icon="mdi:ev-station",
         # identifier here will be ac_charger_name
         is_on_fn=lambda data, identifier: data.get("ac_chargers", {}).get(identifier, {}).get("ac_charger_system_state") in (2,3,4,5),
         # Check if EV is connected (State != 0 (Init) and != 1 (A1_A2))
-        available_fn=lambda data, identifier: data.get("ac_chargers", {}).get(identifier, {}).get("ac_charger_system_state") not in (0, 1),
+        available_fn=ac_charger_command_available,
         turn_on_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 0),
         turn_off_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 1),
+        entity_registry_enabled_default=False,
     ),
 ]
 
@@ -244,7 +245,6 @@ class SigenergySwitch(SigenergyEntity, SwitchEntity):
             raise HomeAssistantError(f"Cannot turn on {self.entity_id}: Coordinator data is unavailable")
         identifier = self._device_name
         await self.entity_description.turn_on_fn(self.coordinator, identifier)
-        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
@@ -252,4 +252,3 @@ class SigenergySwitch(SigenergyEntity, SwitchEntity):
             raise HomeAssistantError(f"Cannot turn off {self.entity_id}: Coordinator data is unavailable")
         identifier = self._device_name
         await self.entity_description.turn_off_fn(self.coordinator, identifier)
-        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Summary

- Deprecates the existing AC charger power switch by renaming it to `AC Charger Power (Deprecated)` and disabling it by default for new entity creation.
- Adds dedicated `Start Charging` and `Stop Charging` AC charger buttons that write to the existing `ac_charger_start_stop` Modbus register.
- Shares AC charger command availability logic through `common.py`, treats missing charger state as unavailable, and avoids duplicate refreshes after writes.

## Why

Issue #349 required the old switch to remain on while the charger is waiting for PV, but that made the switch appear stuck on in the scenario reported in #365. The underlying Modbus control is a write-only start/stop command, so stateless buttons better match the device behavior while preserving the deprecated switch for existing users.

## Validation

- `python -m py_compile custom_components\sigen\common.py custom_components\sigen\button.py custom_components\sigen\switch.py`
- `git diff --check`