### PR TITLE
Fix DC charger switch flapping: derive is_on from running_state instead of instantaneous output power

### DIFF
--- a/custom_components/sigen/switch.py
+++ b/custom_components/sigen/switch.py
@@ -24,6 +24,7 @@ from .const import (
 )
 from .coordinator import SigenergyDataUpdateCoordinator # Import coordinator
 from .sigen_entity import SigenergyEntity # Import the new base class
+from .modbusregisterdefinitions import DCChargerRunningState
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -130,8 +131,13 @@ DC_CHARGER_SWITCHES: list[SigenergySwitchEntityDescription] = [
         key="dc_charging",
         name="DC Charging",
         icon="mdi:ev-station",
-        # CHANGED: is_on_fn now checks != 0 to reflect both charging (positive) and discharging (negative) states
-        is_on_fn=lambda data, identifier: (data.get("dc_chargers", {}).get(identifier, {}).get("dc_charger_output_power", 0) or 0) != 0,
+        # is_on reflects the reported running state (CHARGING or DISCHARGING), not
+        # instantaneous output power. During a genuine session the output power
+        # momentarily reads exactly 0.0 kW at taper/handshake/cycle boundaries, which
+        # made an `output_power != 0` test flap the switch off/on every poll (and, via
+        # plug-in negotiation, a brief on/off on every connect). running_state is the
+        # stable signal and still covers both charging and discharging (like the AC charger).
+        is_on_fn=lambda data, identifier: data.get("dc_chargers", {}).get(identifier, {}).get("dc_charger_running_state") in (DCChargerRunningState.CHARGING, DCChargerRunningState.DISCHARGING),
         turn_on_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 0),
         turn_off_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 1),
     ),


### PR DESCRIPTION
## Problem

`switch.<inverter>_dc_charger_dc_charging` rapidly flaps off/on during a normal charging session, and shows a brief on?off every time a vehicle is plugged in.

The DC charging switch derives `is_on` from `dc_charger_output_power != 0` (no deadband). The reported DC output power legitimately passes through exactly `0.0 kW` for a single poll at every taper / handshake / cycle boundary during an active session, so the switch reports OFF for that scan and ON again on the next one.

## Evidence

Across one real charging session (~5 s poll interval), every observed OFF transition lined up with `dc_charger_output_power` reading exactly `0.0 kW` within a few milliseconds, while `dc_charger_running_state` stayed `Charging` continuously throughout. The underlying charge was never interrupted (continuous multi-kW delivery), so the toggling is purely an artifact of the state derivation. The same mechanism causes the brief on/off on plug-in (output crosses 0 while the charger negotiates Occupied ? Preparing ? Charging).

## Fix

Derive `is_on` from `dc_charger_running_state` being `CHARGING` or `DISCHARGING` instead of `output_power != 0`. This is the stable signal, still covers both charging and discharging (the intent noted in the previous comment), and mirrors how the AC charger switch already derives `is_on` from `ac_charger_system_state`.

- `dc_charger_running_state` (register 31513) is already read and exposed as a sensor - no new register reads.
- `DCChargerRunningState` already exists in `modbusregisterdefinitions.py`; only an import was added to `switch.py`.

?? Generated with [Claude Code](https://claude.com/claude-code)