### PR TITLE
[codex] Add DC charger start stop buttons

### DIFF
--- a/custom_components/sigen/button.py
+++ b/custom_components/sigen/button.py
@@ -13,10 +13,17 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .common import ac_charger_command_available, generate_sigen_entity
+from .common import (
+    ac_charger_command_available,
+    dc_charger_command_available,
+    generate_device_id,
+    generate_sigen_entity,
+)
 from .const import (
     DEVICE_TYPE_AC_CHARGER,
+    DEVICE_TYPE_DC_CHARGER,
     DEVICE_TYPE_PLANT,
+    CONF_INVERTER_HAS_DCCHARGER,
     DOMAIN,
 )
 from .coordinator import SigenergyDataUpdateCoordinator
@@ -59,6 +66,23 @@ AC_CHARGER_BUTTONS: list[SigenergyButtonEntityDescription] = [
     ),
 ]
 
+DC_CHARGER_BUTTONS: list[SigenergyButtonEntityDescription] = [
+    SigenergyButtonEntityDescription(
+        key="dc_charger_start",
+        name="Start Charging",
+        icon="mdi:ev-plug-ccs2",
+        press_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 0),
+        available_fn=dc_charger_command_available,
+    ),
+    SigenergyButtonEntityDescription(
+        key="dc_charger_stop",
+        name="Stop Charging",
+        icon="mdi:ev-plug-ccs2",
+        press_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 1),
+        available_fn=dc_charger_command_available,
+    ),
+]
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -77,6 +101,31 @@ async def async_setup_entry(
         PLANT_BUTTONS,
         DEVICE_TYPE_PLANT,
     )
+
+    for device_name, device_conn in coordinator.hub.inverter_connections.items():
+        if device_conn.get(CONF_INVERTER_HAS_DCCHARGER, False):
+            dc_name = f"{device_name} DC Charger"
+            parent_inverter_id = f"{coordinator.hub.config_entry.entry_id}_{generate_device_id(device_name)}"
+            dc_id = f"{parent_inverter_id}_dc_charger"
+            dc_device_info = DeviceInfo(
+                identifiers={(DOMAIN, dc_id)},
+                name=dc_name,
+                manufacturer="Sigenergy",
+                model="DC Charger",
+                via_device=(DOMAIN, parent_inverter_id),
+            )
+            entities.extend(
+                generate_sigen_entity(
+                    plant_name,
+                    device_name,
+                    device_conn,
+                    coordinator,
+                    SigenergyButton,
+                    DC_CHARGER_BUTTONS,
+                    DEVICE_TYPE_DC_CHARGER,
+                    device_info=dc_device_info,
+                )
+            )
 
     for device_name, device_conn in coordinator.hub.ac_charger_connections.items():
         entities.extend(

--- a/custom_components/sigen/button.py
+++ b/custom_components/sigen/button.py
@@ -77,11 +77,12 @@ DC_CHARGER_BUTTONS: list[SigenergyButtonEntityDescription] = [
     SigenergyButtonEntityDescription(
         key="dc_charger_stop",
         name="Stop Charging",
-        icon="mdi:ev-plug-ccs2",
+        icon="mdi:ev-plug-ccs2-off",
         press_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 1),
         available_fn=dc_charger_command_available,
     ),
 ]
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/sigen/common.py
+++ b/custom_components/sigen/common.py
@@ -14,6 +14,7 @@ from homeassistant.components.sensor import (
 )
 
 from .const import (DOMAIN, DEVICE_TYPE_INVERTER, DEVICE_TYPE_DC_CHARGER)
+from .modbusregisterdefinitions import DCChargerRunningState
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +23,15 @@ def ac_charger_command_available(data: Dict[str, Any], identifier: Optional[Any]
     """Return if AC charger start/stop commands should be exposed."""
     state = data.get("ac_chargers", {}).get(identifier, {}).get("ac_charger_system_state")
     return state is not None and state not in (0, 1)
+
+
+def dc_charger_command_available(data: Dict[str, Any], identifier: Optional[Any]) -> bool:
+    """Return if DC charger start/stop commands should be exposed."""
+    state = data.get("dc_chargers", {}).get(identifier, {}).get("dc_charger_running_state")
+    return state is not None and state not in (
+        DCChargerRunningState.IDLE,
+        DCChargerRunningState.UNAVAILABLE,
+    )
 
 
 def get_suffix_if_not_one(name: str) -> str:

--- a/custom_components/sigen/manifest.json
+++ b/custom_components/sigen/manifest.json
@@ -31,5 +31,5 @@
   "requirements": [
     "pymodbus>=3.8.3"
   ],
-  "version": "1.2.5"
+  "version": "1.2.6"
 }

--- a/custom_components/sigen/switch.py
+++ b/custom_components/sigen/switch.py
@@ -24,6 +24,7 @@ from .const import (
 )
 from .coordinator import SigenergyDataUpdateCoordinator # Import coordinator
 from .sigen_entity import SigenergyEntity # Import the new base class
+from .modbusregisterdefinitions import DCChargerRunningState
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -130,8 +131,13 @@ DC_CHARGER_SWITCHES: list[SigenergySwitchEntityDescription] = [
         key="dc_charging",
         name="DC Charging",
         icon="mdi:ev-station",
-        # CHANGED: is_on_fn now checks != 0 to reflect both charging (positive) and discharging (negative) states
-        is_on_fn=lambda data, identifier: (data.get("dc_chargers", {}).get(identifier, {}).get("dc_charger_output_power", 0) or 0) != 0,
+        # is_on reflects the reported running state (CHARGING or DISCHARGING), not
+        # instantaneous output power. During a genuine session the output power
+        # momentarily reads exactly 0.0 kW at taper/handshake/cycle boundaries, which
+        # made an `output_power != 0` test flap the switch off/on every poll (and, via
+        # plug-in negotiation, a brief on/off on every connect). running_state is the
+        # stable signal and still covers both charging and discharging (like the AC charger).
+        is_on_fn=lambda data, identifier: data.get("dc_chargers", {}).get(identifier, {}).get("dc_charger_running_state") in (DCChargerRunningState.CHARGING, DCChargerRunningState.DISCHARGING),
         turn_on_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 0),
         turn_off_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 1),
     ),

--- a/custom_components/sigen/switch.py
+++ b/custom_components/sigen/switch.py
@@ -49,6 +49,14 @@ def _deprecated_ac_charger_switch_available(data: Dict[str, Any], identifier: Op
     return data.get("ac_chargers", {}).get(identifier, {}).get("ac_charger_system_state") not in (0, 1)
 
 
+def _deprecated_dc_charger_switch_available(data: Dict[str, Any], identifier: Optional[Any]) -> bool:
+    """Preserve legacy switch availability when charger state is missing."""
+    return data.get("dc_chargers", {}).get(identifier, {}).get("dc_charger_running_state") not in (
+        DCChargerRunningState.IDLE,
+        DCChargerRunningState.UNAVAILABLE,
+    )
+
+
 PLANT_SWITCHES: list[SigenergySwitchEntityDescription] = [
     SigenergySwitchEntityDescription(
         key="plant_start_stop",
@@ -129,7 +137,7 @@ AC_CHARGER_SWITCHES: list[SigenergySwitchEntityDescription] = [
 DC_CHARGER_SWITCHES: list[SigenergySwitchEntityDescription] = [
     SigenergySwitchEntityDescription(
         key="dc_charging",
-        name="DC Charging",
+        name="DC Charging (Deprecated)",
         icon="mdi:ev-station",
         # is_on reflects the reported running state (CHARGING or DISCHARGING), not
         # instantaneous output power. During a genuine session the output power
@@ -138,8 +146,10 @@ DC_CHARGER_SWITCHES: list[SigenergySwitchEntityDescription] = [
         # plug-in negotiation, a brief on/off on every connect). running_state is the
         # stable signal and still covers both charging and discharging (like the AC charger).
         is_on_fn=lambda data, identifier: data.get("dc_chargers", {}).get(identifier, {}).get("dc_charger_running_state") in (DCChargerRunningState.CHARGING, DCChargerRunningState.DISCHARGING),
+        available_fn=_deprecated_dc_charger_switch_available,
         turn_on_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 0),
         turn_off_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 1),
+        entity_registry_enabled_default=False,
     ),
 ]
 


### PR DESCRIPTION
## Problem

`dc_charger_start_stop` is a write-only command register (`0: Start`, `1: Stop`), but the integration exposed it through `switch.<inverter>_dc_charger_dc_charging`.

That makes the entity look like a normal latched on/off setting even though its state has to be inferred from charger telemetry. It also means the command surface is tied to the switch's inferred state, instead of being exposed as explicit actions like the AC charger already does.

## Why

Buttons match the command-style behavior better: pressing Start or Stop sends a one-shot command and does not imply the register stores an on/off state.

This also allows the DC charger to be started or stopped from waiting states such as `Scheduled`, where a switch-style state can be misleading but an explicit command is still useful.

## Fix

Add DC charger `Start Charging` and `Stop Charging` button entities, mirroring the existing AC charger buttons.

- `Start Charging` writes `0` to `dc_charger_start_stop`.
- `Stop Charging` writes `1` to `dc_charger_start_stop`.
- The buttons are attached to the DC Charger child device.
- The legacy `DC Charging` switch is renamed `DC Charging (Deprecated)`, hidden by default, and kept with the same entity key for compatibility.

## Validation

- `python -m compileall custom_components/sigen`
- `git diff --check`