### PR TITLE
Hide entities for unsupported Modbus registers

### DIFF
--- a/custom_components/sigen/binary_sensor.py
+++ b/custom_components/sigen/binary_sensor.py
@@ -35,6 +35,8 @@ class SigenergyBinarySensorEntityDescription(
     value_fn: Optional[Callable[[dict[str, Any]], bool | None]] = None
     # Key of the source sensor in the coordinator data dictionary
     source_key: Optional[str] = None
+    # Modbus registers that must all be supported for this derived entity
+    register_support_keys: Optional[tuple[str, ...]] = None
 
 # Define the calculated binary sensors
 PLANT_BINARY_SENSORS: list[SigenergyBinarySensorEntityDescription] = [

--- a/custom_components/sigen/binary_sensor.py
+++ b/custom_components/sigen/binary_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Literal, Optional
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 
@@ -35,8 +35,9 @@ class SigenergyBinarySensorEntityDescription(
     value_fn: Optional[Callable[[dict[str, Any]], bool | None]] = None
     # Key of the source sensor in the coordinator data dictionary
     source_key: Optional[str] = None
-    # Modbus registers that must all be supported for this derived entity
+    # Modbus registers used to determine support for this derived entity
     register_support_keys: Optional[tuple[str, ...]] = None
+    register_support_mode: Literal["all", "any"] = "all"
 
 # Define the calculated binary sensors
 PLANT_BINARY_SENSORS: list[SigenergyBinarySensorEntityDescription] = [
@@ -46,6 +47,11 @@ PLANT_BINARY_SENSORS: list[SigenergyBinarySensorEntityDescription] = [
         device_class=BinarySensorDeviceClass.POWER,
         icon="mdi:solar-power",
         source_key=None,  # No longer a direct key, calculated from multiple values
+        register_support_keys=(
+            "plant_sigen_photovoltaic_power",
+            "plant_third_party_photovoltaic_power",
+        ),
+        register_support_mode="any",
         value_fn=lambda data: (
             (
                 power := SigenergyCalculations.calculate_total_pv_power(

--- a/custom_components/sigen/button.py
+++ b/custom_components/sigen/button.py
@@ -37,6 +37,7 @@ class SigenergyButtonEntityDescription(ButtonEntityDescription):
 
     press_fn: Callable[[SigenergyDataUpdateCoordinator, Optional[Any]], Coroutine[Any, Any, None]] = lambda coordinator, identifier: asyncio.sleep(0)
     available_fn: Callable[[Dict[str, Any], Optional[Any]], bool] = lambda data, _: True
+    register_support_keys: Optional[tuple[str, ...]] = None
 
 
 PLANT_BUTTONS: list[SigenergyButtonEntityDescription] = [
@@ -56,6 +57,7 @@ AC_CHARGER_BUTTONS: list[SigenergyButtonEntityDescription] = [
         icon="mdi:ev-plug-type2",
         press_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 0),
         available_fn=ac_charger_command_available,
+        register_support_keys=("ac_charger_system_state",),
     ),
     SigenergyButtonEntityDescription(
         key="ac_charger_stop",
@@ -63,6 +65,7 @@ AC_CHARGER_BUTTONS: list[SigenergyButtonEntityDescription] = [
         icon="mdi:ev-plug-type2-off",
         press_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 1),
         available_fn=ac_charger_command_available,
+        register_support_keys=("ac_charger_system_state",),
     ),
 ]
 
@@ -73,6 +76,7 @@ DC_CHARGER_BUTTONS: list[SigenergyButtonEntityDescription] = [
         icon="mdi:ev-plug-ccs2",
         press_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 0),
         available_fn=dc_charger_command_available,
+        register_support_keys=("dc_charger_running_state",),
     ),
     SigenergyButtonEntityDescription(
         key="dc_charger_stop",
@@ -80,6 +84,7 @@ DC_CHARGER_BUTTONS: list[SigenergyButtonEntityDescription] = [
         icon="mdi:ev-plug-ccs2-off",
         press_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 1),
         available_fn=dc_charger_command_available,
+        register_support_keys=("dc_charger_running_state",),
     ),
 ]
 

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -1882,6 +1882,14 @@ class SigenergyCalculatedSensors:
             icon="mdi:home-lightning-bolt",
             value_fn=SigenergyCalculations.calculate_plant_consumed_power,
             extra_fn_data=True,  # Pass coordinator data to value_fn
+            register_support_alternatives=(
+                ("plant_general_load_power",),
+                (
+                    "plant_active_power",
+                    "plant_grid_sensor_active_power",
+                    "plant_third_party_photovoltaic_power",
+                ),
+            ),
             suggested_display_precision=3,
             round_digits=6,
         ),

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -1894,6 +1894,9 @@ class SigenergyCalculatedSensors:
             state_class=SensorStateClass.TOTAL_INCREASING,
             value_fn=SigenergyCalculations.calculate_plant_daily_pv_energy,
             extra_fn_data=True,  # Pass coordinator data to value_fn
+            register_support_keys=("inverter_daily_pv_energy",),
+            register_support_scope="inverters",
+            register_support_mode="any",
             max_sub_interval=timedelta(seconds=30),
             icon="mdi:solar-power",
         ),
@@ -1932,6 +1935,9 @@ class SigenergyCalculatedSensors:
             icon="mdi:battery-positive",
             value_fn=SigenergyCalculations.calculate_daily_battery_charge_energy,
             extra_fn_data=True, # Pass coordinator data to value_fn
+            register_support_keys=("inverter_ess_daily_charge_energy",),
+            register_support_scope="inverters",
+            register_support_mode="any",
             suggested_display_precision=2,
             round_digits=6, # Match other energy sensors
         ),
@@ -1944,6 +1950,9 @@ class SigenergyCalculatedSensors:
             icon="mdi:battery-negative",
             value_fn=SigenergyCalculations.calculate_daily_battery_discharge_energy,
             extra_fn_data=True, # Pass coordinator data to value_fn
+            register_support_keys=("inverter_ess_daily_discharge_energy",),
+            register_support_scope="inverters",
+            register_support_mode="any",
             suggested_display_precision=2,
             round_digits=6, # Match other energy sensors
         ),

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -1839,6 +1839,11 @@ class SigenergyCalculatedSensors:
             icon="mdi:solar-power",
             value_fn=SigenergyCalculations.calculate_total_pv_power,
             extra_fn_data=True,  # Pass coordinator data to value_fn
+            register_support_keys=(
+                "plant_sigen_photovoltaic_power",
+                "plant_third_party_photovoltaic_power",
+            ),
+            register_support_mode="any",
             suggested_display_precision=3,
             round_digits=6,
         ),

--- a/custom_components/sigen/calculated_sensor.py
+++ b/custom_components/sigen/calculated_sensor.py
@@ -1783,6 +1783,7 @@ class SigenergyCalculatedSensors:
             state_class=SensorStateClass.MEASUREMENT,
             value_fn=SigenergyCalculations.calculate_pv_power,
             extra_fn_data=True,
+            register_support_keys=("voltage", "current"),
             suggested_display_precision=3,
             round_digits=6,
             icon="mdi:solar-power",
@@ -1850,6 +1851,7 @@ class SigenergyCalculatedSensors:
             icon="mdi:transmission-tower-export",
             value_fn=SigenergyCalculations.calculate_grid_import_power,
             extra_fn_data=True,  # Pass coordinator data to value_fn
+            register_support_keys=("plant_grid_sensor_active_power",),
             suggested_display_precision=3,
             round_digits=6,
         ),
@@ -1862,6 +1864,7 @@ class SigenergyCalculatedSensors:
             icon="mdi:transmission-tower-import",
             value_fn=SigenergyCalculations.calculate_grid_export_power,
             extra_fn_data=True,  # Pass coordinator data to value_fn
+            register_support_keys=("plant_grid_sensor_active_power",),
             suggested_display_precision=3,
             round_digits=6,
         ),
@@ -1976,6 +1979,12 @@ class SigenergyCalculatedSensors:
             icon="mdi:current-dc",
             value_fn=SigenergyCalculations.calculate_ess_current,
             extra_fn_data=True,
+            register_support_keys=(
+                "inverter_ess_charge_discharge_power",
+                "inverter_ess_average_cell_voltage",
+                "inverter_pack_count",
+                "inverter_rated_battery_capacity",
+            ),
             entity_registry_enabled_default=False,
         ),
     ]

--- a/custom_components/sigen/common.py
+++ b/custom_components/sigen/common.py
@@ -92,10 +92,24 @@ def get_entity_register_support(
     register_support_keys = resolve_register_support_keys(
         description, pv_string_idx
     )
+    if getattr(description, "register_support_scope", "entity") == "inverters":
+        support_targets = tuple(
+            (DEVICE_TYPE_INVERTER, inverter_name)
+            for inverter_name in hub.inverter_connections
+        )
+    else:
+        support_targets = ((device_type, device_name),)
+
     support_states = tuple(
-        hub.get_register_support(device_type, device_name, register_name)
+        hub.get_register_support(
+            support_device_type, support_device_name, register_name
+        )
+        for support_device_type, support_device_name in support_targets
         for register_name in register_support_keys
     )
+
+    if not support_states:
+        return None, register_support_keys
 
     if getattr(description, "register_support_mode", "all") == "any":
         if any(state is True for state in support_states):
@@ -355,6 +369,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
     extra_fn_data: Optional[bool] = False  # Flag to indicate if value_fn needs coordinator data
     extra_params: Optional[Dict[str, Any]] = None  # Additional parameters for value_fn
     register_support_keys: Optional[tuple[str, ...]] = None
+    register_support_scope: Literal["entity", "inverters"] = "entity"
     register_support_mode: Literal["all", "any"] = "all"
     source_entity_id: Optional[str] = None
     source_key: Optional[str] = None  # Key of the source entity to use for integration
@@ -381,6 +396,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
 				extra_fn_data=extra_fn_data if extra_fn_data is not None else description.extra_fn_data,
 				extra_params=extra_params or description.extra_params,
 				register_support_keys=description.register_support_keys,
+				register_support_scope=description.register_support_scope,
 				register_support_mode=description.register_support_mode,
 				source_entity_id=description.source_entity_id,
 				source_key=description.source_key,
@@ -400,6 +416,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
             extra_fn_data=extra_fn_data,
             extra_params=extra_params,
             register_support_keys=getattr(description, "register_support_keys", None),
+            register_support_scope=getattr(description, "register_support_scope", "entity"),
             register_support_mode=getattr(description, "register_support_mode", "all"),
         )
 

--- a/custom_components/sigen/common.py
+++ b/custom_components/sigen/common.py
@@ -6,7 +6,10 @@ from datetime import timedelta
 from decimal import Decimal, InvalidOperation
 from typing import Any, Optional, Callable, Dict
 from dataclasses import dataclass
-from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
+from homeassistant.helpers.entity_registry import (
+    async_entries_for_config_entry,
+    async_get as async_get_entity_registry,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.components.sensor import (
@@ -75,6 +78,37 @@ def generate_sigen_entity(
     entities = []
     for description in entity_description:
         # _LOGGER.debug("Generating entity for description: %s", description.name)
+
+        register_support = coordinator.hub.get_register_support(
+            device_type,
+            device_name,
+            description.key,
+        )
+        if register_support is False:
+            unique_id = generate_unique_entity_id(
+                device_type,
+                device_name,
+                coordinator,
+                description.key,
+                pv_string_idx,
+            )
+            entity_registry = async_get_entity_registry(coordinator.hass)
+            for registry_entry in async_entries_for_config_entry(
+                entity_registry, coordinator.hub.config_entry.entry_id
+            ):
+                if registry_entry.unique_id == unique_id:
+                    entity_registry.async_remove(registry_entry.entity_id)
+                    _LOGGER.info(
+                        "Removed unsupported entity %s from the entity registry",
+                        registry_entry.entity_id,
+                    )
+            _LOGGER.debug(
+                "Skipping entity '%s' because register '%s' is unsupported by %s",
+                description.name,
+                description.key,
+                device_name,
+            )
+            continue
 
         # Generate PV specific entity names and IDs if applicable
         if pv_string_idx is not None:

--- a/custom_components/sigen/common.py
+++ b/custom_components/sigen/common.py
@@ -7,6 +7,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, Optional, Callable, Dict
 from dataclasses import dataclass
 from homeassistant.helpers.entity_registry import (
+    RegistryEntryHider,
     async_entries_for_config_entry,
     async_get as async_get_entity_registry,
 )
@@ -41,6 +42,16 @@ def get_suffix_if_not_one(name: str) -> str:
     """Get the last part of the name if it is a number other than 1."""
     return name.split()[-1].strip() + " " if len(name.split()) > 1 and name.split()[-1].isdigit() and name.split()[-1] != "1" else ""
 
+
+def resolve_register_support_key(
+    register_name: str, pv_string_idx: Optional[int] = None
+) -> str:
+    """Resolve an entity description key to its Modbus register name."""
+    if pv_string_idx is not None and register_name in {"voltage", "current"}:
+        return f"inverter_pv{pv_string_idx}_{register_name}"
+    return register_name
+
+
 def generate_device_name(plant_name: str, device_name: str) -> str:
     """Generate a device name based on plant name and device name."""
     device_type = " ".join(device_name.split()[:-1]) if len(device_name.split()) > 1 and device_name.split()[-1].isdigit() else device_name
@@ -74,15 +85,26 @@ def generate_sigen_entity(
         list: A list of instantiated entities for the device
     """
     device_name = device_name if device_name else plant_name
+    entity_registry = async_get_entity_registry(coordinator.hass)
+    registry_entries_by_unique_id = {}
+    for registry_entry in async_entries_for_config_entry(
+        entity_registry, coordinator.hub.config_entry.entry_id
+    ):
+        registry_entries_by_unique_id.setdefault(
+            registry_entry.unique_id, []
+        ).append(registry_entry)
 
     entities = []
     for description in entity_description:
         # _LOGGER.debug("Generating entity for description: %s", description.name)
 
+        register_support_key = resolve_register_support_key(
+            description.key, pv_string_idx
+        )
         register_support = coordinator.hub.get_register_support(
             device_type,
             device_name,
-            description.key,
+            register_support_key,
         )
         if register_support is False:
             unique_id = generate_unique_entity_id(
@@ -92,23 +114,42 @@ def generate_sigen_entity(
                 description.key,
                 pv_string_idx,
             )
-            entity_registry = async_get_entity_registry(coordinator.hass)
-            for registry_entry in async_entries_for_config_entry(
-                entity_registry, coordinator.hub.config_entry.entry_id
-            ):
-                if registry_entry.unique_id == unique_id:
-                    entity_registry.async_remove(registry_entry.entity_id)
+            for registry_entry in registry_entries_by_unique_id.get(unique_id, []):
+                if registry_entry.hidden_by is None:
+                    entity_registry.async_update_entity(
+                        registry_entry.entity_id,
+                        hidden_by=RegistryEntryHider.INTEGRATION,
+                    )
                     _LOGGER.info(
-                        "Removed unsupported entity %s from the entity registry",
+                        "Hid unsupported entity %s while preserving its registry entry",
                         registry_entry.entity_id,
                     )
             _LOGGER.debug(
                 "Skipping entity '%s' because register '%s' is unsupported by %s",
                 description.name,
-                description.key,
+                register_support_key,
                 device_name,
             )
             continue
+
+        if register_support is True:
+            unique_id = generate_unique_entity_id(
+                device_type,
+                device_name,
+                coordinator,
+                description.key,
+                pv_string_idx,
+            )
+            for registry_entry in registry_entries_by_unique_id.get(unique_id, []):
+                if registry_entry.hidden_by is RegistryEntryHider.INTEGRATION:
+                    entity_registry.async_update_entity(
+                        registry_entry.entity_id,
+                        hidden_by=None,
+                    )
+                    _LOGGER.info(
+                        "Unhid supported entity %s",
+                        registry_entry.entity_id,
+                    )
 
         # Generate PV specific entity names and IDs if applicable
         if pv_string_idx is not None:

--- a/custom_components/sigen/common.py
+++ b/custom_components/sigen/common.py
@@ -89,9 +89,6 @@ def get_entity_register_support(
     pv_string_idx: Optional[int] = None,
 ) -> tuple[Optional[bool], tuple[str, ...]]:
     """Return aggregate support and backing register keys for an entity."""
-    register_support_keys = resolve_register_support_keys(
-        description, pv_string_idx
-    )
     if getattr(description, "register_support_scope", "entity") == "inverters":
         support_targets = tuple(
             (DEVICE_TYPE_INVERTER, inverter_name)
@@ -100,6 +97,53 @@ def get_entity_register_support(
     else:
         support_targets = ((device_type, device_name),)
 
+    register_support_alternatives = getattr(
+        description, "register_support_alternatives", None
+    )
+    if register_support_alternatives:
+        resolved_alternatives = tuple(
+            tuple(
+                resolve_register_support_key(register_name, pv_string_idx)
+                for register_name in alternative
+            )
+            for alternative in register_support_alternatives
+        )
+        register_support_keys = tuple(
+            dict.fromkeys(
+                register_name
+                for alternative in resolved_alternatives
+                for register_name in alternative
+            )
+        )
+        alternative_states = []
+        for alternative in resolved_alternatives:
+            states = tuple(
+                hub.get_register_support(
+                    support_device_type, support_device_name, register_name
+                )
+                for support_device_type, support_device_name in support_targets
+                for register_name in alternative
+            )
+            if not states:
+                alternative_states.append(None)
+            elif any(state is False for state in states):
+                alternative_states.append(False)
+            elif all(state is True for state in states):
+                alternative_states.append(True)
+            else:
+                alternative_states.append(None)
+
+        if any(state is True for state in alternative_states):
+            return True, register_support_keys
+        if alternative_states and all(
+            state is False for state in alternative_states
+        ):
+            return False, register_support_keys
+        return None, register_support_keys
+
+    register_support_keys = resolve_register_support_keys(
+        description, pv_string_idx
+    )
     support_states = tuple(
         hub.get_register_support(
             support_device_type, support_device_name, register_name
@@ -369,6 +413,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
     extra_fn_data: Optional[bool] = False  # Flag to indicate if value_fn needs coordinator data
     extra_params: Optional[Dict[str, Any]] = None  # Additional parameters for value_fn
     register_support_keys: Optional[tuple[str, ...]] = None
+    register_support_alternatives: Optional[tuple[tuple[str, ...], ...]] = None
     register_support_scope: Literal["entity", "inverters"] = "entity"
     register_support_mode: Literal["all", "any"] = "all"
     source_entity_id: Optional[str] = None
@@ -396,6 +441,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
 				extra_fn_data=extra_fn_data if extra_fn_data is not None else description.extra_fn_data,
 				extra_params=extra_params or description.extra_params,
 				register_support_keys=description.register_support_keys,
+				register_support_alternatives=description.register_support_alternatives,
 				register_support_scope=description.register_support_scope,
 				register_support_mode=description.register_support_mode,
 				source_entity_id=description.source_entity_id,
@@ -416,7 +462,12 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
             extra_fn_data=extra_fn_data,
             extra_params=extra_params,
             register_support_keys=getattr(description, "register_support_keys", None),
-            register_support_scope=getattr(description, "register_support_scope", "entity"),
+            register_support_alternatives=getattr(
+                description, "register_support_alternatives", None
+            ),
+            register_support_scope=getattr(
+                description, "register_support_scope", "entity"
+            ),
             register_support_mode=getattr(description, "register_support_mode", "all"),
         )
 

--- a/custom_components/sigen/common.py
+++ b/custom_components/sigen/common.py
@@ -52,6 +52,58 @@ def resolve_register_support_key(
     return register_name
 
 
+def resolve_register_support_keys(
+    description: Any, pv_string_idx: Optional[int] = None
+) -> tuple[str, ...]:
+    """Resolve all Modbus registers required by an entity description."""
+    explicit_keys = getattr(description, "register_support_keys", None)
+    if explicit_keys:
+        register_names = (
+            (explicit_keys,) if isinstance(explicit_keys, str) else tuple(explicit_keys)
+        )
+    else:
+        extra_params = getattr(description, "extra_params", None) or {}
+        register_name = extra_params.get("register_name")
+        source_key = getattr(description, "source_key", None)
+
+        if register_name:
+            register_names = (register_name,)
+        elif source_key == "pv_string_power" and pv_string_idx is not None:
+            register_names = ("voltage", "current")
+        elif source_key:
+            register_names = (source_key,)
+        else:
+            register_names = (description.key,)
+
+    return tuple(
+        resolve_register_support_key(register_name, pv_string_idx)
+        for register_name in register_names
+    )
+
+
+def get_entity_register_support(
+    hub,
+    device_type: str,
+    device_name: Optional[str],
+    description: Any,
+    pv_string_idx: Optional[int] = None,
+) -> tuple[Optional[bool], tuple[str, ...]]:
+    """Return aggregate support and backing register keys for an entity."""
+    register_support_keys = resolve_register_support_keys(
+        description, pv_string_idx
+    )
+    support_states = tuple(
+        hub.get_register_support(device_type, device_name, register_name)
+        for register_name in register_support_keys
+    )
+
+    if any(state is False for state in support_states):
+        return False, register_support_keys
+    if all(state is True for state in support_states):
+        return True, register_support_keys
+    return None, register_support_keys
+
+
 def generate_device_name(plant_name: str, device_name: str) -> str:
     """Generate a device name based on plant name and device name."""
     device_type = " ".join(device_name.split()[:-1]) if len(device_name.split()) > 1 and device_name.split()[-1].isdigit() else device_name
@@ -98,13 +150,12 @@ def generate_sigen_entity(
     for description in entity_description:
         # _LOGGER.debug("Generating entity for description: %s", description.name)
 
-        register_support_key = resolve_register_support_key(
-            description.key, pv_string_idx
-        )
-        register_support = coordinator.hub.get_register_support(
+        register_support, register_support_keys = get_entity_register_support(
+            coordinator.hub,
             device_type,
             device_name,
-            register_support_key,
+            description,
+            pv_string_idx,
         )
         if register_support is False:
             unique_id = generate_unique_entity_id(
@@ -125,9 +176,10 @@ def generate_sigen_entity(
                         registry_entry.entity_id,
                     )
             _LOGGER.debug(
-                "Skipping entity '%s' because register '%s' is unsupported by %s",
+                "Skipping entity '%s' because backing register(s) '%s' are "
+                "unsupported by %s",
                 description.name,
-                register_support_key,
+                ", ".join(register_support_keys),
                 device_name,
             )
             continue
@@ -295,6 +347,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
     value_fn: Optional[Callable[[Any, Optional[Dict[str, Any]], Optional[Dict[str, Any]]], Any]] = None
     extra_fn_data: Optional[bool] = False  # Flag to indicate if value_fn needs coordinator data
     extra_params: Optional[Dict[str, Any]] = None  # Additional parameters for value_fn
+    register_support_keys: Optional[tuple[str, ...]] = None
     source_entity_id: Optional[str] = None
     source_key: Optional[str] = None  # Key of the source entity to use for integration
     max_sub_interval: Optional[timedelta] = None
@@ -319,6 +372,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
 				value_fn=value_fn or description.value_fn,
 				extra_fn_data=extra_fn_data if extra_fn_data is not None else description.extra_fn_data,
 				extra_params=extra_params or description.extra_params,
+				register_support_keys=description.register_support_keys,
 				source_entity_id=description.source_entity_id,
 				source_key=description.source_key,
 				max_sub_interval=description.max_sub_interval,
@@ -336,6 +390,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
             value_fn=value_fn,
             extra_fn_data=extra_fn_data,
             extra_params=extra_params,
+            register_support_keys=getattr(description, "register_support_keys", None),
         )
 
 def safe_float(value: Any, precision: int = 6) -> Optional[float]:

--- a/custom_components/sigen/common.py
+++ b/custom_components/sigen/common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 from decimal import Decimal, InvalidOperation
-from typing import Any, Optional, Callable, Dict
+from typing import Any, Optional, Callable, Dict, Literal
 from dataclasses import dataclass
 from homeassistant.helpers.entity_registry import (
     RegistryEntryHider,
@@ -96,6 +96,13 @@ def get_entity_register_support(
         hub.get_register_support(device_type, device_name, register_name)
         for register_name in register_support_keys
     )
+
+    if getattr(description, "register_support_mode", "all") == "any":
+        if any(state is True for state in support_states):
+            return True, register_support_keys
+        if all(state is False for state in support_states):
+            return False, register_support_keys
+        return None, register_support_keys
 
     if any(state is False for state in support_states):
         return False, register_support_keys
@@ -348,6 +355,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
     extra_fn_data: Optional[bool] = False  # Flag to indicate if value_fn needs coordinator data
     extra_params: Optional[Dict[str, Any]] = None  # Additional parameters for value_fn
     register_support_keys: Optional[tuple[str, ...]] = None
+    register_support_mode: Literal["all", "any"] = "all"
     source_entity_id: Optional[str] = None
     source_key: Optional[str] = None  # Key of the source entity to use for integration
     max_sub_interval: Optional[timedelta] = None
@@ -373,6 +381,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
 				extra_fn_data=extra_fn_data if extra_fn_data is not None else description.extra_fn_data,
 				extra_params=extra_params or description.extra_params,
 				register_support_keys=description.register_support_keys,
+				register_support_mode=description.register_support_mode,
 				source_entity_id=description.source_entity_id,
 				source_key=description.source_key,
 				max_sub_interval=description.max_sub_interval,
@@ -391,6 +400,7 @@ class SigenergySensorEntityDescription(SensorEntityDescription):
             extra_fn_data=extra_fn_data,
             extra_params=extra_params,
             register_support_keys=getattr(description, "register_support_keys", None),
+            register_support_mode=getattr(description, "register_support_mode", "all"),
         )
 
 def safe_float(value: Any, precision: int = 6) -> Optional[float]:

--- a/custom_components/sigen/manifest.json
+++ b/custom_components/sigen/manifest.json
@@ -31,5 +31,5 @@
   "requirements": [
     "pymodbus>=3.8.3"
   ],
-  "version": "1.2.6"
+  "version": "1.2.7"
 }

--- a/custom_components/sigen/modbus.py
+++ b/custom_components/sigen/modbus.py
@@ -220,6 +220,7 @@ class SigenergyModbusHub:
         # Track last failed probe times for retry logic (1 minute retry delay)
         self.plant_last_probe_failure: Optional[float] = None
         self.inverter_last_probe_failure: Dict[str, float] = {}
+        self.ac_charger_last_probe_failure: Dict[str, float] = {}
         self.dc_charger_last_probe_failure: Dict[str, float] = {}
         self.probe_retry_delay: float = 60.0  # 1 minute retry delay
 
@@ -281,6 +282,20 @@ class SigenergyModbusHub:
         except (KeyError, TypeError, ValueError):
             return None
         return self._register_support.get(support_key, {}).get(register_name)
+
+    def _has_unresolved_register_support(
+        self,
+        device_type: str,
+        device_info: Dict[str, Any],
+        register_defs: Dict[str, ModbusRegisterDefinition],
+    ) -> bool:
+        """Return whether one or more readable registers still need probing."""
+        try:
+            support_key = self._get_register_support_key(device_type, device_info)
+        except (KeyError, TypeError, ValueError):
+            return True
+        register_support = self._register_support.get(support_key, {})
+        return any(name not in register_support for name in register_defs)
     
     def _should_retry_probe(self, device_type: str, device_name: Optional[str] = None) -> bool:
         """Check if enough time has passed since last probe failure to retry."""
@@ -294,6 +309,10 @@ class SigenergyModbusHub:
             if device_name not in self.inverter_last_probe_failure:
                 return True
             return (current_time - self.inverter_last_probe_failure[device_name]) >= self.probe_retry_delay
+        elif device_type == "ac_charger" and device_name:
+            if device_name not in self.ac_charger_last_probe_failure:
+                return True
+            return (current_time - self.ac_charger_last_probe_failure[device_name]) >= self.probe_retry_delay
         elif device_type == "dc_charger" and device_name:
             if device_name not in self.dc_charger_last_probe_failure:
                 return True
@@ -308,6 +327,8 @@ class SigenergyModbusHub:
             self.plant_last_probe_failure = current_time
         elif device_type == "inverter" and device_name:
             self.inverter_last_probe_failure[device_name] = current_time
+        elif device_type == "ac_charger" and device_name:
+            self.ac_charger_last_probe_failure[device_name] = current_time
         elif device_type == "dc_charger" and device_name:
             self.dc_charger_last_probe_failure[device_name] = current_time
 
@@ -1050,23 +1071,38 @@ class SigenergyModbusHub:
 
     async def async_read_plant_data(self) -> Dict[str, Any]:
         """Read all supported plant data."""
-        # Probe registers if not done yet
-        if not self.plant_register_intervals:
+        plant_info = {
+            **self.config_entry.data.get(CONF_PLANT_CONNECTION, {}),
+        }
+        plant_info.setdefault(CONF_SLAVE_ID, self.plant_id)
+        registers_to_read = {
+            **PLANT_RUNNING_INFO_REGISTERS,
+            **{name: reg for name, reg in PLANT_PARAMETER_REGISTERS.items()
+               if reg.register_type != RegisterType.WRITE_ONLY},
+            **{name: reg for name, reg in PLANT_ESS_PREHEATING_REGISTERS.items()
+               if reg.register_type != RegisterType.WRITE_ONLY}
+        }
+
+        # Retry only registers whose support state remains unknown. Confirmed
+        # supported and unsupported registers are retained in the per-device map.
+        if self._has_unresolved_register_support(
+            DEVICE_TYPE_PLANT, plant_info, registers_to_read
+        ):
             if self._should_retry_probe("plant"):
                 try:
-                    plant_info = self.config_entry.data.get(CONF_PLANT_CONNECTION, {})
-                    all_plant_registers = {
-                        **PLANT_RUNNING_INFO_REGISTERS,
-                        **{name: reg for name, reg in PLANT_PARAMETER_REGISTERS.items()
-                           if reg.register_type != RegisterType.WRITE_ONLY},
-                        **{name: reg for name, reg in PLANT_ESS_PREHEATING_REGISTERS.items()
-                           if reg.register_type != RegisterType.WRITE_ONLY}
-                    }
                     _LOGGER.debug("Attempting to probe plant registers on %s...", plant_info)
                     self.plant_register_intervals = await self.async_probe_registers(
-                        plant_info, all_plant_registers, DEVICE_TYPE_PLANT
+                        plant_info, registers_to_read, DEVICE_TYPE_PLANT
                     )
-                    _LOGGER.info("Plant register probing successful")
+                    if self._has_unresolved_register_support(
+                        DEVICE_TYPE_PLANT, plant_info, registers_to_read
+                    ):
+                        self._record_probe_failure("plant")
+                        _LOGGER.debug(
+                            "Plant register probing incomplete; retrying in 1 minute"
+                        )
+                    else:
+                        _LOGGER.info("Plant register probing successful")
                 except asyncio.CancelledError:
                     _LOGGER.warning("Plant register probing was cancelled, will retry in 1 minute")
                     self._record_probe_failure("plant")
@@ -1077,19 +1113,9 @@ class SigenergyModbusHub:
             else:
                 _LOGGER.debug("Skipping plant register probing - waiting for retry delay")
 
-        # Read all running info and parameter registers
-        registers_to_read = {
-            **PLANT_RUNNING_INFO_REGISTERS,
-            **{name: reg for name, reg in PLANT_PARAMETER_REGISTERS.items()
-               if reg.register_type != RegisterType.WRITE_ONLY},
-            **{name: reg for name, reg in PLANT_ESS_PREHEATING_REGISTERS.items()
-               if reg.register_type != RegisterType.WRITE_ONLY}
-        }
         # _LOGGER.debug("Reading %s Plant registers.", len(registers_to_read))
 
         # Use the core reading logic
-        plant_info = self.config_entry.data.get(CONF_PLANT_CONNECTION, {})
-        plant_info.setdefault(CONF_SLAVE_ID, self.plant_id)
         from homeassistant.const import CONF_NAME
         plant_name = self.config_entry.data.get(CONF_NAME, "plant")
         return await self._async_read_device_data_core(
@@ -1108,22 +1134,31 @@ class SigenergyModbusHub:
             _LOGGER.error("Unknown inverter name provided for reading data: %s", inverter_name)
             return {} # Return empty dict if inverter name is not found
         inverter_info = self.inverter_connections[inverter_name]
+        registers_to_read = {
+            **INVERTER_RUNNING_INFO_REGISTERS,
+            **{name: reg for name, reg in INVERTER_PARAMETER_REGISTERS.items()
+               if reg.register_type != RegisterType.WRITE_ONLY}
+        }
 
-        # Probe registers if not done yet for this inverter
-        if inverter_name not in self.inverter_register_intervals:
+        if self._has_unresolved_register_support(
+            DEVICE_TYPE_INVERTER, inverter_info, registers_to_read
+        ):
             if self._should_retry_probe("inverter", inverter_name):
                 try:
-                    # Combine all readable registers for one probe call
-                    all_inverter_registers = {
-                        **INVERTER_RUNNING_INFO_REGISTERS,
-                        **{name: reg for name, reg in INVERTER_PARAMETER_REGISTERS.items()
-                           if reg.register_type != RegisterType.WRITE_ONLY}
-                    }
                     _LOGGER.debug("Attempting to probe inverter '%s' registers on %s...", inverter_name, inverter_info)
                     self.inverter_register_intervals[inverter_name] = await self.async_probe_registers(
-                        inverter_info, all_inverter_registers, DEVICE_TYPE_INVERTER
+                        inverter_info, registers_to_read, DEVICE_TYPE_INVERTER
                     )
-                    _LOGGER.info("Inverter '%s' register probing successful", inverter_name)
+                    if self._has_unresolved_register_support(
+                        DEVICE_TYPE_INVERTER, inverter_info, registers_to_read
+                    ):
+                        self._record_probe_failure("inverter", inverter_name)
+                        _LOGGER.debug(
+                            "Inverter '%s' register probing incomplete; retrying in 1 minute",
+                            inverter_name,
+                        )
+                    else:
+                        _LOGGER.info("Inverter '%s' register probing successful", inverter_name)
                 except asyncio.CancelledError:
                     _LOGGER.warning("Inverter '%s' register probing was cancelled, will retry in 1 minute", inverter_name)
                     self._record_probe_failure("inverter", inverter_name)
@@ -1134,12 +1169,6 @@ class SigenergyModbusHub:
             else:
                 _LOGGER.debug("Skipping inverter '%s' register probing - waiting for retry delay", inverter_name)
 
-        # Read all running info and parameter registers
-        registers_to_read = {
-            **INVERTER_RUNNING_INFO_REGISTERS,
-            **{name: reg for name, reg in INVERTER_PARAMETER_REGISTERS.items()
-               if reg.register_type != RegisterType.WRITE_ONLY}
-        }
         # _LOGGER.debug("Reading %s Inverter registers.", len(registers_to_read))
 
         # Use the core reading logic
@@ -1159,22 +1188,31 @@ class SigenergyModbusHub:
             _LOGGER.error("Unknown inverter name provided for reading DC Charger data: %s", inverter_name)
             return {} # Return empty dict if inverter name is not found
         inverter_info = self.inverter_connections[inverter_name]
+        registers_to_read = {
+            **DC_CHARGER_RUNNING_INFO_REGISTERS,
+            **{name: reg for name, reg in DC_CHARGER_PARAMETER_REGISTERS.items()
+               if reg.register_type != RegisterType.WRITE_ONLY}
+        }
 
-        # Probe registers if not done yet for this inverter
-        if inverter_name not in self.dc_charger_register_intervals:
+        if self._has_unresolved_register_support(
+            DEVICE_TYPE_DC_CHARGER, inverter_info, registers_to_read
+        ):
             if self._should_retry_probe("dc_charger", inverter_name):
                 try:
-                    # Combine all readable registers for one probe call
-                    all_dc_charger_registers = {
-                        **DC_CHARGER_RUNNING_INFO_REGISTERS,
-                        **{name: reg for name, reg in DC_CHARGER_PARAMETER_REGISTERS.items()
-                           if reg.register_type != RegisterType.WRITE_ONLY}
-                    }
                     _LOGGER.debug("Attempting to probe DC charger '%s' registers on %s...", inverter_name, inverter_info)
                     self.dc_charger_register_intervals[inverter_name] = await self.async_probe_registers(
-                        inverter_info, all_dc_charger_registers, DEVICE_TYPE_DC_CHARGER
+                        inverter_info, registers_to_read, DEVICE_TYPE_DC_CHARGER
                     )
-                    _LOGGER.info("DC charger '%s' register probing successful", inverter_name)
+                    if self._has_unresolved_register_support(
+                        DEVICE_TYPE_DC_CHARGER, inverter_info, registers_to_read
+                    ):
+                        self._record_probe_failure("dc_charger", inverter_name)
+                        _LOGGER.debug(
+                            "DC charger '%s' register probing incomplete; retrying in 1 minute",
+                            inverter_name,
+                        )
+                    else:
+                        _LOGGER.info("DC charger '%s' register probing successful", inverter_name)
                 except asyncio.CancelledError:
                     _LOGGER.warning("DC charger '%s' register probing was cancelled, will retry in 1 minute", inverter_name)
                     self._record_probe_failure("dc_charger", inverter_name)
@@ -1185,12 +1223,6 @@ class SigenergyModbusHub:
             else:
                 _LOGGER.debug("Skipping DC charger '%s' register probing - waiting for retry delay", inverter_name)
 
-        # Read all running info and parameter registers
-        registers_to_read = {
-            **DC_CHARGER_RUNNING_INFO_REGISTERS,
-            **{name: reg for name, reg in DC_CHARGER_PARAMETER_REGISTERS.items()
-               if reg.register_type != RegisterType.WRITE_ONLY}
-        }
         # _LOGGER.debug("Reading %s DC charger registers.", len(registers_to_read))
 
         # Use the core reading logic
@@ -1211,29 +1243,44 @@ class SigenergyModbusHub:
             return {}  # Return empty dict if AC charger name is not found
 
         ac_charger_info = self.ac_charger_connections[ac_charger_name]
-
-        # Probe registers if not done yet for this AC charger
-        if ac_charger_name not in self.ac_charger_register_intervals:
-            try:
-                # Combine all readable registers for one probe call
-                all_ac_charger_registers = {
-                    **AC_CHARGER_RUNNING_INFO_REGISTERS,
-                    **{name: reg for name, reg in AC_CHARGER_PARAMETER_REGISTERS.items()
-                       if reg.register_type != RegisterType.WRITE_ONLY}
-                }
-                self.ac_charger_register_intervals[ac_charger_name] = await self.async_probe_registers(
-                    ac_charger_info, all_ac_charger_registers, DEVICE_TYPE_AC_CHARGER
-                )
-            except Exception as ex:
-                _LOGGER.error("Failed to probe AC charger '%s' registers: %s", ac_charger_name, ex)
-                # Continue with reading, some registers might still work
-
-        # Read all running info and parameter registers
         registers_to_read = {
             **AC_CHARGER_RUNNING_INFO_REGISTERS,
             **{name: reg for name, reg in AC_CHARGER_PARAMETER_REGISTERS.items()
                if reg.register_type != RegisterType.WRITE_ONLY}
         }
+
+        if self._has_unresolved_register_support(
+            DEVICE_TYPE_AC_CHARGER, ac_charger_info, registers_to_read
+        ):
+            if self._should_retry_probe("ac_charger", ac_charger_name):
+                try:
+                    self.ac_charger_register_intervals[ac_charger_name] = await self.async_probe_registers(
+                        ac_charger_info, registers_to_read, DEVICE_TYPE_AC_CHARGER
+                    )
+                    if self._has_unresolved_register_support(
+                        DEVICE_TYPE_AC_CHARGER, ac_charger_info, registers_to_read
+                    ):
+                        self._record_probe_failure("ac_charger", ac_charger_name)
+                        _LOGGER.debug(
+                            "AC charger '%s' register probing incomplete; retrying in 1 minute",
+                            ac_charger_name,
+                        )
+                except asyncio.CancelledError:
+                    _LOGGER.warning(
+                        "AC charger '%s' register probing was cancelled, will retry in 1 minute",
+                        ac_charger_name,
+                    )
+                    self._record_probe_failure("ac_charger", ac_charger_name)
+                    raise
+                except Exception as ex:
+                    _LOGGER.error("Failed to probe AC charger '%s' registers: %s", ac_charger_name, ex)
+                    self._record_probe_failure("ac_charger", ac_charger_name)
+            else:
+                _LOGGER.debug(
+                    "Skipping AC charger '%s' register probing - waiting for retry delay",
+                    ac_charger_name,
+                )
+
         # _LOGGER.debug("Reading %s AC charger registers.", len(registers_to_read))
 
         # Use the core reading logic

--- a/custom_components/sigen/modbus.py
+++ b/custom_components/sigen/modbus.py
@@ -27,6 +27,10 @@ from .const import (
     CONF_PLANT_CONNECTION,
     DEFAULT_PLANT_SLAVE_ID,
     DEFAULT_READ_ONLY,
+    DEVICE_TYPE_PLANT,
+    DEVICE_TYPE_INVERTER,
+    DEVICE_TYPE_AC_CHARGER,
+    DEVICE_TYPE_DC_CHARGER,
 )
 from .modbusregisterdefinitions import (
     DataType,
@@ -44,6 +48,8 @@ from .modbusregisterdefinitions import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+ILLEGAL_DATA_ADDRESS = 0x02
 
 # Pymodbus version compatibility handling
 def _get_pymodbus_version_info():
@@ -203,6 +209,13 @@ class SigenergyModbusHub:
         self.inverter_register_intervals: Dict[str, Dict[RegisterType, List[Tuple[int, int]]]] = {}
         self.ac_charger_register_intervals: Dict[str, Dict[RegisterType, List[Tuple[int, int]]]] = {}
         self.dc_charger_register_intervals: Dict[str, Dict[RegisterType, List[Tuple[int, int]]]] = {}
+
+        # Register support belongs to a specific device. The register definitions
+        # are module-level objects and must not carry runtime state between hubs or
+        # devices.
+        self._register_support: Dict[
+            Tuple[str, str, int, int], Dict[str, bool]
+        ] = {}
         
         # Track last failed probe times for retry logic (1 minute retry delay)
         self.plant_last_probe_failure: Optional[float] = None
@@ -213,6 +226,61 @@ class SigenergyModbusHub:
     def _get_connection_key(self, device_info: dict) -> Tuple[str, int]:
         """Get the connection key (host, port) for a device_info dict."""
         return (device_info[CONF_HOST], device_info[CONF_PORT])
+
+    def _get_register_support_key(
+        self, device_type: str, device_info: Dict[str, Any]
+    ) -> Tuple[str, str, int, int]:
+        """Return the per-device key used for runtime register support."""
+        slave_id = device_info.get(CONF_SLAVE_ID)
+        if slave_id is None:
+            if device_type == DEVICE_TYPE_PLANT:
+                slave_id = self.plant_id
+            else:
+                raise ValueError(f"Slave ID is missing in device info: {device_info}")
+        return (
+            device_type,
+            str(device_info[CONF_HOST]),
+            int(device_info[CONF_PORT]),
+            int(slave_id),
+        )
+
+    def _get_device_info_for_register_support(
+        self, device_type: str, device_name: Optional[str]
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve connection information for an entity's device."""
+        if device_type == DEVICE_TYPE_PLANT:
+            return {
+                **self.plant_connection,
+                CONF_SLAVE_ID: self.plant_connection.get(
+                    CONF_SLAVE_ID, self.plant_id
+                ),
+            }
+        if device_type == DEVICE_TYPE_INVERTER:
+            return self.inverter_connections.get(device_name or "")
+        if device_type == DEVICE_TYPE_AC_CHARGER:
+            return self.ac_charger_connections.get(device_name or "")
+        if device_type == DEVICE_TYPE_DC_CHARGER:
+            inverter_name = (device_name or "").replace(" DC Charger", "").strip()
+            return self.inverter_connections.get(inverter_name)
+        return None
+
+    def get_register_support(
+        self,
+        device_type: str,
+        device_name: Optional[str],
+        register_name: str,
+    ) -> Optional[bool]:
+        """Return True, False, or None for a device register's support state."""
+        device_info = self._get_device_info_for_register_support(
+            device_type, device_name
+        )
+        if device_info is None:
+            return None
+        try:
+            support_key = self._get_register_support_key(device_type, device_info)
+        except (KeyError, TypeError, ValueError):
+            return None
+        return self._register_support.get(support_key, {}).get(register_name)
     
     def _should_retry_probe(self, device_type: str, device_name: Optional[str] = None) -> bool:
         """Check if enough time has passed since last probe failure to retry."""
@@ -322,67 +390,45 @@ class SigenergyModbusHub:
                 self._connected[key] = False
                 _LOGGER.info("Disconnected from Sigenergy system at %s:%s", host, port)
 
-    def _validate_register_response(self, result: Any,
-                                    register_def: ModbusRegisterDefinition) -> bool:
-        """Validate if register response indicates support for the register."""
-        # Handle error responses silently - these indicate unsupported registers
-        if result is None or (hasattr(result, 'isError') and result.isError()):
-            _LOGGER.debug("Register validation failed for address"
-                          f" {register_def.address} with error: %s", result)
-            return False
-
-        registers = getattr(result, 'registers', [])
-        if not registers:
-            _LOGGER.debug("Register validation failed for address %s: empty response",
-                          register_def.address)
-            return False
-
-        # For string type registers, check if all values are 0 (indicating no support)
-        if register_def.data_type == DataType.STRING:
+    def _validate_register_response(
+        self, result: Any, register_def: ModbusRegisterDefinition
+    ) -> Optional[bool]:
+        """Classify a register probe as supported, unsupported, or unknown."""
+        if result is None:
             _LOGGER.debug(
-                "Register validation failed for address %s: string type "
-                "(not all string registers have to be filled)",
-                register_def.address
+                "Register probe for address %s returned no response",
+                register_def.address,
             )
-            return not all(reg == 0 for reg in registers)
+            return None
 
-        # For numeric registers, check if values are within reasonable bounds
-        try:
-            value = self._decode_value(registers, register_def.data_type, register_def.gain)
-            if isinstance(value, (int, float)):
-                # Consider register supported if value is non-zero and within reasonable bounds
-                # This helps filter out invalid/unsupported registers that might return garbage
-                max_reasonable = {
-                    "voltage": 1000,  # 1000V
-                    "current": 1000,  # 1000A
-                    "power": 1000,     # 1000kW
-                    "energy": 10000000, # 10000MWh
-                    "temperature": 200, # 200°C
-                    "percentage": 120  # 120% Some batteries can go above 100% when charging
-                }
+        if hasattr(result, "isError") and result.isError():
+            exception_code = getattr(result, "exception_code", None)
+            if exception_code == ILLEGAL_DATA_ADDRESS:
+                _LOGGER.debug(
+                    "Register address %s is unsupported (illegal data address)",
+                    register_def.address,
+                )
+                return False
+            _LOGGER.debug(
+                "Register probe for address %s was inconclusive: %s",
+                register_def.address,
+                result,
+            )
+            return None
 
-                # Determine max value based on unit if present
-                if register_def.unit:
-                    unit = register_def.unit.lower()
-                    if any(u in unit for u in ["v", "volt"]):
-                        return 0 <= abs(value) <= max_reasonable["voltage"]
-                    elif any(u in unit for u in ["a", "amp"]):
-                        return 0 <= abs(value) <= max_reasonable["current"]
-                    elif any(u in unit for u in ["wh", "kwh"]):
-                        return 0 <= abs(value) <= max_reasonable["energy"]
-                    elif any(u in unit for u in ["w", "watt"]):
-                        return 0 <= abs(value) <= max_reasonable["power"]
-                    elif any(u in unit for u in ["c", "f", "temp"]):
-                        return -50 <= value <= max_reasonable["temperature"]
-                    elif "%" in unit:
-                        return 0 <= value <= max_reasonable["percentage"]
-                # Default validation - accept any value including 0
-                return True
+        registers = getattr(result, "registers", [])
+        if len(registers) < register_def.count:
+            _LOGGER.debug(
+                "Register probe for address %s returned %d of %d registers",
+                register_def.address,
+                len(registers),
+                register_def.count,
+            )
+            return None
 
-            return True
-        except Exception as ex:
-            _LOGGER.debug("Register validation failed with exception: %s", ex)
-            return False
+        # A successful Modbus response proves that the address exists. Zero is a
+        # valid value for alarms and for empty optional string fields.
+        return True
 
     async def _probe_single_register(
         self,
@@ -391,44 +437,49 @@ class SigenergyModbusHub:
         name: str,
         register: ModbusRegisterDefinition,
         device_info_log: str # Added for logging context
-    ) -> Tuple[str, bool, Optional[Exception]]:
+    ) -> Tuple[str, Optional[bool], Optional[Exception]]:
         """Probe a single register and return its name, support status, and any exception."""
 
-        with _suppress_pymodbus_logging(really_suppress= False if _LOGGER.isEnabledFor(logging.DEBUG) else True):
-            if register.register_type == RegisterType.READ_ONLY:
-                result = await _call_modbus_method_safe(
-                    client.read_input_registers,
-                    address=register.address,
-                    count=register.count,
-                    slave=slave_id
-                )
-            elif register.register_type == RegisterType.HOLDING:
-                result = await _call_modbus_method_safe(
-                    client.read_holding_registers,
-                    address=register.address,
-                    count=register.count,
-                    slave=slave_id
-                )
-            else:
-                _LOGGER.debug(
-                    "Register %s (0x%04X) for slave %d (%s) has unsupported type: %s",
-                    name, register.address, slave_id, device_info_log, register.register_type
-                )
-                return name, False, None # Mark as unsupported, no exception
+        try:
+            with _suppress_pymodbus_logging(
+                really_suppress=not _LOGGER.isEnabledFor(logging.DEBUG)
+            ):
+                if register.register_type == RegisterType.READ_ONLY:
+                    result = await _call_modbus_method_safe(
+                        client.read_input_registers,
+                        address=register.address,
+                        count=register.count,
+                        slave=slave_id,
+                    )
+                elif register.register_type == RegisterType.HOLDING:
+                    result = await _call_modbus_method_safe(
+                        client.read_holding_registers,
+                        address=register.address,
+                        count=register.count,
+                        slave=slave_id,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Register %s (0x%04X) for slave %d (%s) has unreadable type: %s",
+                        name,
+                        register.address,
+                        slave_id,
+                        device_info_log,
+                        register.register_type,
+                    )
+                    return name, None, None
 
-            is_supported = self._validate_register_response(result, register)
-
-            # if _LOGGER.isEnabledFor(logging.DEBUG) and not is_supported:
-            #     _LOGGER.debug(
-            #         "Register %s (%s) for device %s is not supported. Result: %s, registers: %s",
-            #         name, register.address, device_info_log, str(result), str(register)
-            #     )
-            return name, is_supported, None # Return name, support status, no exception
+                return name, self._validate_register_response(result, register), None
+        except asyncio.CancelledError:
+            raise
+        except Exception as ex:
+            return name, None, ex
 
     async def async_probe_registers(
         self,
         device_info: Dict[str, str | int],
-        register_defs: Dict[str, ModbusRegisterDefinition]
+        register_defs: Dict[str, ModbusRegisterDefinition],
+        device_type: str,
     ) -> Dict[RegisterType, List[Tuple[int, int]]]:
         """
         Probe registers to determine support and create optimal read intervals.
@@ -443,6 +494,8 @@ class SigenergyModbusHub:
         slave_id = int(slave_id_value)
         client = await self._get_client(device_info)
         key = self._get_connection_key(device_info)
+        support_key = self._get_register_support_key(device_type, device_info)
+        register_support = self._register_support.setdefault(support_key, {})
         device_info_log = f"{key[0]}:{key[1]}@{slave_id}" # For logging
 
         tasks = []
@@ -451,17 +504,13 @@ class SigenergyModbusHub:
                 # Create tasks for probing each register
                 for name, register in register_defs.items():
                     # Only probe if support status is unknown (None)
-                    if register.is_supported is None:
+                    if register_support.get(name) is None:
                         tasks.append(
                             self._probe_single_register(client, slave_id, name, register, device_info_log)
                         )
         except Exception as ex:
             _LOGGER.error("Error while preparing register probing tasks for %s: %s",
                           device_info_log, ex)
-            # Mark all probed registers as potentially unsupported due to the error
-            for name, register in register_defs.items():
-                if register.is_supported is None:
-                    register.is_supported = False
             return {}
 
         if not tasks:
@@ -484,10 +533,6 @@ class SigenergyModbusHub:
             except Exception as ex:
                 _LOGGER.error("Unexpected error during concurrent register probing for %s: %s",
                               device_info_log, ex)
-                # Mark all probed registers as potentially unsupported due to the gather error
-                for name, register in register_defs.items():
-                    if register.is_supported is None: # Only update those that were being probed
-                        register.is_supported = False
                 self._connected[key] = False # Assume connection issue
                 return {} # Exit probing on major error
 
@@ -506,14 +551,15 @@ class SigenergyModbusHub:
                                            SigenergyModbusError)):
                         connection_error_occurred = True
                     # We don't know which register failed here, so we can't mark it specifically.
-                    # The registers remain is_supported=None and will be retried on read.
+                    # The register remains unknown and can be probed again later.
                     continue # Skip to next result
 
                 # Unpack successful results
                 if isinstance(result, tuple) and len(result) == 3:
                     name, is_supported, probe_exception = result
                     if name in register_defs:
-                        register_defs[name].is_supported = is_supported
+                        if is_supported is not None:
+                            register_support[name] = is_supported
                         if probe_exception:
                             # Log the specific exception caught by _probe_single_register
                             _LOGGER.debug("Probe failed for register %s on %s: %s",
@@ -530,11 +576,14 @@ class SigenergyModbusHub:
 
 
         _LOGGER.debug("Probing completed for %s. Supported registers: %s", device_info_log,
-                      {name: register.is_supported for name, register in register_defs.items() \
-                       if register.is_supported})
+                      {name: status for name, status in register_support.items() if status})
 
         # Create address intervals for optimized reading
-        supported_registers = [reg for reg in register_defs.values() if reg.is_supported]
+        supported_registers = [
+            register
+            for name, register in register_defs.items()
+            if register_support.get(name) is True
+        ]
 
         registers_by_type: Dict[RegisterType, List[ModbusRegisterDefinition]] = {}
         for reg in supported_registers:
@@ -902,6 +951,7 @@ class SigenergyModbusHub:
         self,
         device_info: Dict[str, Any],
         device_name: str,
+        device_type: str,
         device_type_log_prefix: str,
         registers_to_read: Dict[str, ModbusRegisterDefinition],
         read_intervals: Dict[RegisterType, List[Tuple[int, int]]]
@@ -938,11 +988,13 @@ class SigenergyModbusHub:
                         start_address, device_type_log_prefix, device_name, ex
                     )
 
+        support_key = self._get_register_support_key(device_type, device_info)
+        register_support = self._register_support.get(support_key, {})
         data = {}
         # 2. Decode the read data for each specific register
         for register_name, register_def in registers_to_read.items():
             # Skip unsupported or disabled registers
-            if not register_def.is_supported:
+            if register_support.get(register_name) is not True:
                 continue
 
             # Find the interval data that contains this register
@@ -1012,7 +1064,7 @@ class SigenergyModbusHub:
                     }
                     _LOGGER.debug("Attempting to probe plant registers on %s...", plant_info)
                     self.plant_register_intervals = await self.async_probe_registers(
-                        plant_info, all_plant_registers
+                        plant_info, all_plant_registers, DEVICE_TYPE_PLANT
                     )
                     _LOGGER.info("Plant register probing successful")
                 except asyncio.CancelledError:
@@ -1043,6 +1095,7 @@ class SigenergyModbusHub:
         return await self._async_read_device_data_core(
             device_info=plant_info,
             device_name=plant_name,
+            device_type=DEVICE_TYPE_PLANT,
             device_type_log_prefix="plant",
             registers_to_read=registers_to_read,
             read_intervals=self.plant_register_intervals
@@ -1068,7 +1121,7 @@ class SigenergyModbusHub:
                     }
                     _LOGGER.debug("Attempting to probe inverter '%s' registers on %s...", inverter_name, inverter_info)
                     self.inverter_register_intervals[inverter_name] = await self.async_probe_registers(
-                        inverter_info, all_inverter_registers
+                        inverter_info, all_inverter_registers, DEVICE_TYPE_INVERTER
                     )
                     _LOGGER.info("Inverter '%s' register probing successful", inverter_name)
                 except asyncio.CancelledError:
@@ -1093,6 +1146,7 @@ class SigenergyModbusHub:
         return await self._async_read_device_data_core(
             device_info=inverter_info,
             device_name=inverter_name,
+            device_type=DEVICE_TYPE_INVERTER,
             device_type_log_prefix="inverter",
             registers_to_read=registers_to_read,
             read_intervals=self.inverter_register_intervals.get(inverter_name, {})
@@ -1118,7 +1172,7 @@ class SigenergyModbusHub:
                     }
                     _LOGGER.debug("Attempting to probe DC charger '%s' registers on %s...", inverter_name, inverter_info)
                     self.dc_charger_register_intervals[inverter_name] = await self.async_probe_registers(
-                        inverter_info, all_dc_charger_registers
+                        inverter_info, all_dc_charger_registers, DEVICE_TYPE_DC_CHARGER
                     )
                     _LOGGER.info("DC charger '%s' register probing successful", inverter_name)
                 except asyncio.CancelledError:
@@ -1143,6 +1197,7 @@ class SigenergyModbusHub:
         return await self._async_read_device_data_core(
             device_info=inverter_info,
             device_name=inverter_name,
+            device_type=DEVICE_TYPE_DC_CHARGER,
             device_type_log_prefix="dc charger",
             registers_to_read=registers_to_read,
             read_intervals=self.dc_charger_register_intervals.get(inverter_name, {})
@@ -1167,7 +1222,7 @@ class SigenergyModbusHub:
                        if reg.register_type != RegisterType.WRITE_ONLY}
                 }
                 self.ac_charger_register_intervals[ac_charger_name] = await self.async_probe_registers(
-                    ac_charger_info, all_ac_charger_registers
+                    ac_charger_info, all_ac_charger_registers, DEVICE_TYPE_AC_CHARGER
                 )
             except Exception as ex:
                 _LOGGER.error("Failed to probe AC charger '%s' registers: %s", ac_charger_name, ex)
@@ -1185,6 +1240,7 @@ class SigenergyModbusHub:
         return await self._async_read_device_data_core(
             device_info=ac_charger_info,
             device_name=ac_charger_name,
+            device_type=DEVICE_TYPE_AC_CHARGER,
             device_type_log_prefix="AC charger",
             registers_to_read=registers_to_read,
             read_intervals=self.ac_charger_register_intervals.get(ac_charger_name, {})

--- a/custom_components/sigen/modbusregisterdefinitions.py
+++ b/custom_components/sigen/modbusregisterdefinitions.py
@@ -220,7 +220,6 @@ class ModbusRegisterDefinition:
     unit: Optional[str] = None
     description: Optional[str] = None
     applicable_to: Optional[list[str]] = field(default_factory=lambda: ["hybrid_inverter", "pv_inverter"])
-    is_supported: Optional[bool] = None  # Tracks whether register is supported by device
 
 # Define register definitions based on PLANT_RUNNING_INFO_REGISTERS.csv
 PLANT_RUNNING_INFO_REGISTERS = {

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -161,18 +161,13 @@ async def async_setup_entry(
         
         # Combine sensor descriptions for AC chargers
         ac_charger_sensors = SS.AC_CHARGER_SENSORS + SCS.AC_CHARGER_SENSORS
-        for description in ac_charger_sensors:
-            sensor_name = f"{ac_charger_name} {description.name}"
-            entities_to_add.append(
-                SigenergySensor(
-                    coordinator=coordinator,
-                    description=description,
-                    name=sensor_name,
-                    device_type=DEVICE_TYPE_AC_CHARGER,
-                    device_id=str(slave_id),
-                    device_name=ac_charger_name,
-                )
-            )
+        add_entities_for_device(
+            ac_charger_name,
+            ac_details,
+            ac_charger_sensors,
+            SigenergySensor,
+            DEVICE_TYPE_AC_CHARGER,
+        )
 
     if entities_to_add:
         async_add_entities(entities_to_add)

--- a/custom_components/sigen/sigen_entity.py
+++ b/custom_components/sigen/sigen_entity.py
@@ -23,7 +23,7 @@ from .coordinator import SigenergyDataUpdateCoordinator
 from .common import (
     generate_device_id,
     generate_unique_entity_id,
-    resolve_register_support_key,
+    get_entity_register_support,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -100,9 +100,6 @@ class SigenergyEntity(CoordinatorEntity):
         self._device_name = device_name  # Store device name (e.g., "Inverter 1", "Plant", "AC Charger 1")
         self._pv_string_idx = pv_string_idx
         self._device_info_override = device_info
-        self._register_support_key = resolve_register_support_key(
-            description.key, pv_string_idx
-        )
         self._unsupported_removal_requested = False
 
         # Set unique ID
@@ -124,18 +121,37 @@ class SigenergyEntity(CoordinatorEntity):
         if self._unsupported_removal_requested:
             return
 
+        register_support, register_support_keys = get_entity_register_support(
+            self.hub,
+            self._device_type,
+            self._device_name,
+            self.entity_description,
+            self._pv_string_idx,
+        )
+
+        registry_entry = self.registry_entry
         if (
-            self.hub.get_register_support(
-                self._device_type,
-                self._device_name,
-                self._register_support_key,
-            )
-            is False
+            register_support is True
+            and registry_entry is not None
+            and registry_entry.hidden_by is RegistryEntryHider.INTEGRATION
         ):
-            self._unsupported_removal_requested = True
             entity_registry = async_get_entity_registry(self.hass)
-            if (registry_entry := entity_registry.async_get(self.entity_id)) is not None:
+            entity_registry.async_update_entity(
+                self.entity_id,
+                hidden_by=None,
+            )
+            _LOGGER.info(
+                "Unhid entity %s after backing register(s) '%s' were confirmed "
+                "supported",
+                self.entity_id,
+                ", ".join(register_support_keys),
+            )
+
+        if register_support is False:
+            self._unsupported_removal_requested = True
+            if registry_entry is not None:
                 if registry_entry.hidden_by is None:
+                    entity_registry = async_get_entity_registry(self.hass)
                     entity_registry.async_update_entity(
                         self.entity_id,
                         hidden_by=RegistryEntryHider.INTEGRATION,
@@ -145,9 +161,9 @@ class SigenergyEntity(CoordinatorEntity):
                 self.hass.async_create_task(self.async_remove(force_remove=True))
             _LOGGER.info(
                 "Unloaded unsupported entity %s while preserving its registry entry "
-                "after register '%s' was confirmed unsupported",
+                "after backing register(s) '%s' were confirmed unsupported",
                 self.entity_id,
-                self._register_support_key,
+                ", ".join(register_support_keys),
             )
             return
 

--- a/custom_components/sigen/sigen_entity.py
+++ b/custom_components/sigen/sigen_entity.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
+from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_registry import (
+    RegistryEntryHider,
+    async_get as async_get_entity_registry,
+)
 from homeassistant.helpers.update_coordinator import CoordinatorEntity  # pylint: disable=syntax-error
 
 from .const import (
@@ -15,7 +20,11 @@ from .const import (
     DEVICE_TYPE_DC_CHARGER,
 )
 from .coordinator import SigenergyDataUpdateCoordinator
-from .common import generate_unique_entity_id, generate_device_id
+from .common import (
+    generate_device_id,
+    generate_unique_entity_id,
+    resolve_register_support_key,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -91,6 +100,10 @@ class SigenergyEntity(CoordinatorEntity):
         self._device_name = device_name  # Store device name (e.g., "Inverter 1", "Plant", "AC Charger 1")
         self._pv_string_idx = pv_string_idx
         self._device_info_override = device_info
+        self._register_support_key = resolve_register_support_key(
+            description.key, pv_string_idx
+        )
+        self._unsupported_removal_requested = False
 
         # Set unique ID
         self._attr_unique_id = generate_unique_entity_id(
@@ -104,6 +117,41 @@ class SigenergyEntity(CoordinatorEntity):
             self._attr_device_info = _generate_device_info(
                 device_type, device_name, coordinator
             )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data and remove newly confirmed unsupported entities."""
+        if self._unsupported_removal_requested:
+            return
+
+        if (
+            self.hub.get_register_support(
+                self._device_type,
+                self._device_name,
+                self._register_support_key,
+            )
+            is False
+        ):
+            self._unsupported_removal_requested = True
+            entity_registry = async_get_entity_registry(self.hass)
+            if (registry_entry := entity_registry.async_get(self.entity_id)) is not None:
+                if registry_entry.hidden_by is None:
+                    entity_registry.async_update_entity(
+                        self.entity_id,
+                        hidden_by=RegistryEntryHider.INTEGRATION,
+                    )
+                self.hass.async_create_task(self.async_remove())
+            else:
+                self.hass.async_create_task(self.async_remove(force_remove=True))
+            _LOGGER.info(
+                "Unloaded unsupported entity %s while preserving its registry entry "
+                "after register '%s' was confirmed unsupported",
+                self.entity_id,
+                self._register_support_key,
+            )
+            return
+
+        super()._handle_coordinator_update()
 
     @property
     def available(self) -> bool:

--- a/custom_components/sigen/switch.py
+++ b/custom_components/sigen/switch.py
@@ -42,6 +42,7 @@ class SigenergySwitchEntityDescription(SwitchEntityDescription):
     turn_off_fn: Callable[[SigenergyDataUpdateCoordinator, Optional[Any]], Coroutine[Any, Any, None]] = lambda coordinator, identifier: asyncio.sleep(0) # Placeholder async lambda
     available_fn: Callable[[Dict[str, Any], Optional[Any]], bool] = lambda data, _: True
     entity_registry_enabled_default: bool = True
+    register_support_keys: Optional[tuple[str, ...]] = None
 
 
 def _deprecated_ac_charger_switch_available(data: Dict[str, Any], identifier: Optional[Any]) -> bool:
@@ -130,6 +131,7 @@ AC_CHARGER_SWITCHES: list[SigenergySwitchEntityDescription] = [
         available_fn=_deprecated_ac_charger_switch_available,
         turn_on_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 0),
         turn_off_fn=lambda coordinator, identifier: coordinator.async_write_parameter("ac_charger", identifier, "ac_charger_start_stop", 1),
+        register_support_keys=("ac_charger_system_state",),
         entity_registry_enabled_default=False,
     ),
 ]
@@ -149,6 +151,7 @@ DC_CHARGER_SWITCHES: list[SigenergySwitchEntityDescription] = [
         available_fn=_deprecated_dc_charger_switch_available,
         turn_on_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 0),
         turn_off_fn=lambda coordinator, identifier: coordinator.async_write_parameter("dc_charger", identifier, "dc_charger_start_stop", 1),
+        register_support_keys=("dc_charger_running_state",),
         entity_registry_enabled_default=False,
     ),
 ]


### PR DESCRIPTION
## Summary

- track Modbus register support per physical device instead of mutating shared register definitions
- classify only Modbus exception `0x02 ILLEGAL DATA ADDRESS` as confirmed unsupported
- resolve raw, PV-string, source-key, lifetime, and multi-register dependencies before exposing derived entities
- hide and unload entities backed by confirmed unsupported registers without deleting their entity-registry records
- unhide integration-hidden entities when a later retry confirms support
- keep valid zero values supported so Alarm 7 still reports `No Problem` when register 30281 returns `0`
- bump the integration version to 1.2.7

## Why

Systems that do not expose the optional Alarm 7 register (30281) currently still create the General Alarm 7 entity. Because the coordinator has no raw value, Home Assistant presents the entity as `unknown`, even though no Alarm 7 condition has been reported.

Register support was also stored on module-level register definitions, allowing one device's probe result to affect another device or config entry.

## Impact

Devices that return `ILLEGAL DATA ADDRESS` for a register no longer expose the corresponding raw or derived entity. Systems that support register 30281 continue to decode OVGR and RPR faults normally. Transient or inconclusive Modbus errors are not treated as proof that a register is unsupported.

Existing unsupported entities are marked `hidden_by=integration` and unloaded without deleting their entity-registry records, entity IDs, or historical association. User-hidden entries are not changed. If a later retry confirms support, only the integration's own hide marker is removed.

## Validation

- parsed all 17 integration Python files successfully
- validated `manifest.json`
- passed `git diff --check`
- locally verified valid zero responses, exception `0x02`, inconclusive Modbus errors, per-device isolation, retries, raw and derived dependency filtering, late unhide behavior, user-hidden preservation, and registry-history preservation
- HACS Action passed
- hassfest passed

A full Home Assistant runtime test was not available in the local environment.

Closes #397