### PR TITLE
Persist read-only setting during plant setup

### DIFF
--- a/custom_components/sigen/config_flow.py
+++ b/custom_components/sigen/config_flow.py
@@ -78,6 +78,7 @@ DEFAULT_PLANT_CONNECTION = {
                 CONF_HOST: "",
                 CONF_PORT: DEFAULT_PORT,
                 CONF_INVERTER_SLAVE_ID: DEFAULT_INVERTER_SLAVE_ID,
+                CONF_READ_ONLY: DEFAULT_READ_ONLY,
                 CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
 }
 
@@ -302,6 +303,7 @@ class SigenergyConfigFlow(config_entries.ConfigFlow):
         new_plant_connection[CONF_SLAVE_ID] = DEFAULT_PLANT_SLAVE_ID
         new_plant_connection[CONF_INVERTER_SLAVE_ID] = \
             self._discovered_device_type[DEVICE_TYPE_INVERTER][0]
+        new_plant_connection[CONF_READ_ONLY] = user_input[CONF_READ_ONLY]
         self._data[CONF_PLANT_CONNECTION] = new_plant_connection
         self._data[CONF_INVERTER_CONNECTIONS] = {}
         self._data[CONF_AC_CHARGER_CONNECTIONS] = {}
@@ -482,6 +484,7 @@ class SigenergyConfigFlow(config_entries.ConfigFlow):
         new_plant_connection[CONF_HOST] = user_input[CONF_HOST]
         new_plant_connection[CONF_PORT] = user_input[CONF_PORT]
         new_plant_connection[CONF_SLAVE_ID] = DEFAULT_PLANT_SLAVE_ID
+        new_plant_connection[CONF_READ_ONLY] = user_input[CONF_READ_ONLY]
         new_plant_connection[CONF_SCAN_INTERVAL] = user_input[CONF_SCAN_INTERVAL]
         self._data[CONF_PLANT_CONNECTION] = new_plant_connection
 


### PR DESCRIPTION
## Summary

- persist the selected Read-Only setting when a plant is configured manually
- persist the selected Read-Only setting for DHCP-discovered plants
- keep `DEFAULT_READ_ONLY = True` as the safe default

## Root cause

The configuration forms collected `read_only`, but both plant creation paths rebuilt `plant_connection` without copying that value. The Modbus hub then treated the missing key as `DEFAULT_READ_ONLY`, which is correctly `True`, so writes remained blocked even when the user had disabled Read-Only mode during setup.

## User impact

New plant configurations will now honor the value selected in the setup UI. Existing configuration entries and Home Assistant history are not modified.

Users already affected must update the stored setting manually after installing the fixed version:

1. Open **Settings → Devices & services → Sigenergy ESS → Configure**.
2. Select the plant.
3. Clear **Read-Only** and save.

Saving the plant configuration writes the previously missing value and reloads the integration. Users should not change `DEFAULT_READ_ONLY` in the source code.

## Validation

- `git diff --check`
- Python syntax compilation of `config_flow.py`
- targeted AST regression check confirming persistence in both manual and DHCP setup paths

Fixes #387