### PR TITLE
Fix transient zero bounce on EVDC lifetime energy

### DIFF
--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -481,3 +481,4 @@ class CoordinatorDiagnosticSensor(SigenergyEntity, SensorEntity):
         except Exception as e:
             _LOGGER.exception("Unexpected error in CoordinatorDiagnosticSensor for %s: %s", self.entity_id, e)
             return None
+

--- a/custom_components/sigen/sensor.py
+++ b/custom_components/sigen/sensor.py
@@ -63,6 +63,13 @@ _PROTECTED_DAILY_ENERGY_KEYS = frozenset({
     "inverter_ess_daily_discharge_energy",
 })
 
+# Lifetime energy sensor keys where zero is never a legitimate reset after a
+# positive reading has been observed. Keep these separate from daily counters:
+# daily counters may reset around midnight, while lifetime counters must not.
+_PROTECTED_LIFETIME_ENERGY_KEYS = frozenset({
+    "dc_charger_total_charging_capacity",
+})
+
 # Legitimate midnight resets are allowed within ±20 minutes of 00:00.
 _DAILY_RESET_WINDOW = timedelta(minutes=20)
 
@@ -227,14 +234,16 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
         window = _DAILY_RESET_WINDOW.total_seconds()
         return seconds_since_midnight <= window or seconds_since_midnight >= 86400 - window
 
-    def _apply_daily_energy_zero_guard(self, value: Any) -> Any:
-        """Suppress transient zero drops for daily energy sensors outside the midnight window.
+    def _apply_energy_zero_guard(self, value: Any) -> Any:
+        """Suppress transient zero drops for protected energy sensors.
 
-        When a Modbus reconnection causes the inverter to briefly report 0 for a daily
-        energy counter, this converts that 0 to None (unavailable) so HA's TOTAL_INCREASING
-        handling does not interpret the recovery as new phantom production.
+        Daily counters may legitimately reset around midnight. Lifetime counters
+        never legitimately reset after a positive value has been observed.
         """
-        if self.entity_description.key not in _PROTECTED_DAILY_ENERGY_KEYS:
+        key = self.entity_description.key
+        is_daily = key in _PROTECTED_DAILY_ENERGY_KEYS
+        is_lifetime = key in _PROTECTED_LIFETIME_ENERGY_KEYS
+        if not is_daily and not is_lifetime:
             return value
         if value is None:
             return value
@@ -246,13 +255,16 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
         today = dt_util.now().date()
         last_date = self._last_valid_daily_energy_date
         if decimal_value == 0:
-            if self._is_near_daily_reset() or (last_date is not None and last_date < today):
+            if is_daily and (
+                self._is_near_daily_reset()
+                or (last_date is not None and last_date < today)
+            ):
                 self._last_valid_daily_energy_value = decimal_value
                 self._last_valid_daily_energy_date = today
                 return value
             if last is not None and last > 0:
                 _LOGGER.debug(
-                    "[%s] Suppressing transient zero (last valid: %s) outside midnight window",
+                    "[%s] Suppressing transient zero (last valid: %s)",
                     self.entity_id,
                     last,
                 )
@@ -312,8 +324,8 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
 
                 # Round if needed
                 if transformed is not None and self._round_digits is not None:
-                    return self._apply_daily_energy_zero_guard(round(Decimal(transformed), self._round_digits))
-                return self._apply_daily_energy_zero_guard(transformed)
+                    return self._apply_energy_zero_guard(round(Decimal(transformed), self._round_digits))
+                return self._apply_energy_zero_guard(transformed)
             except Exception as ex:
                 if raw_value is None:
                     _LOGGER.debug("Value function failed for %s because data is missing: %s", self.entity_id, ex)
@@ -373,11 +385,11 @@ class SigenergySensor(SigenergyEntity, SensorEntity):
 
         if self._round_digits is not None:
             try:
-                return self._apply_daily_energy_zero_guard(round(Decimal(raw_value), self._round_digits))
+                return self._apply_energy_zero_guard(round(Decimal(raw_value), self._round_digits))
             except (TypeError, ValueError, InvalidOperation):
                 _LOGGER.warning("Could not round direct value for %s: %s", self.entity_id, raw_value)
 
-        return self._apply_daily_energy_zero_guard(raw_value)
+        return self._apply_energy_zero_guard(raw_value)
 
 
 class PVStringSensor(SigenergySensor):
@@ -469,4 +481,3 @@ class CoordinatorDiagnosticSensor(SigenergyEntity, SensorEntity):
         except Exception as e:
             _LOGGER.exception("Unexpected error in CoordinatorDiagnosticSensor for %s: %s", self.entity_id, e)
             return None
-

--- a/tests/test_energy_zero_guard.py
+++ b/tests/test_energy_zero_guard.py
@@ -1,0 +1,93 @@
+"""Regression tests for protected energy zero-bounce handling."""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+
+SOURCE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "sigen"
+    / "sensor.py"
+)
+
+
+def _source_tree() -> ast.Module:
+    return ast.parse(SOURCE_PATH.read_text(encoding="utf-8"))
+
+
+def _assigned_string_set(tree: ast.Module, name: str) -> set[str]:
+    assignment = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == name for target in node.targets)
+    )
+    call = assignment.value
+    assert isinstance(call, ast.Call)
+    values = call.args[0]
+    assert isinstance(values, ast.Set)
+    return {
+        element.value
+        for element in values.elts
+        if isinstance(element, ast.Constant) and isinstance(element.value, str)
+    }
+
+
+class TestEnergyZeroGuard(unittest.TestCase):
+    """Ensure lifetime and daily energy counters keep distinct reset rules."""
+
+    def test_dc_charger_total_is_protected_as_lifetime_energy(self) -> None:
+        tree = _source_tree()
+
+        self.assertIn(
+            "dc_charger_total_charging_capacity",
+            _assigned_string_set(tree, "_PROTECTED_LIFETIME_ENERGY_KEYS"),
+        )
+        self.assertNotIn(
+            "dc_charger_total_charging_capacity",
+            _assigned_string_set(tree, "_PROTECTED_DAILY_ENERGY_KEYS"),
+        )
+
+    def test_midnight_reset_exception_is_limited_to_daily_energy(self) -> None:
+        tree = _source_tree()
+        sensor_class = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "SigenergySensor"
+        )
+        guard = next(
+            node
+            for node in sensor_class.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_apply_energy_zero_guard"
+        )
+
+        midnight_calls = [
+            node
+            for node in ast.walk(guard)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_is_near_daily_reset"
+        ]
+        self.assertEqual(1, len(midnight_calls))
+
+        midnight_if = next(
+            node
+            for node in ast.walk(guard)
+            if isinstance(node, ast.If)
+            and any(call is midnight_calls[0] for call in ast.walk(node.test))
+        )
+        self.assertTrue(
+            any(
+                isinstance(node, ast.Name) and node.id == "is_daily"
+                for node in ast.walk(midnight_if.test)
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_energy_zero_guard.py
+++ b/tests/test_energy_zero_guard.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import ast
 import unittest
+from datetime import datetime
+from decimal import Decimal
 from pathlib import Path
+from types import MethodType, SimpleNamespace
+from unittest.mock import Mock
 
 
 SOURCE_PATH = (
@@ -37,6 +41,46 @@ def _assigned_string_set(tree: ast.Module, name: str) -> set[str]:
     }
 
 
+def _guard_for(key: str, *, last: Decimal | None, near_reset: bool):
+    """Load the guard in isolation so these tests do not require Home Assistant."""
+    tree = _source_tree()
+    sensor_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "SigenergySensor"
+    )
+    guard = next(
+        node
+        for node in sensor_class.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_apply_energy_zero_guard"
+    )
+    module = ast.fix_missing_locations(ast.Module(body=[guard], type_ignores=[]))
+    namespace = {
+        "Any": object,
+        "Decimal": Decimal,
+        "InvalidOperation": ArithmeticError,
+        "_LOGGER": Mock(),
+        "_PROTECTED_DAILY_ENERGY_KEYS": _assigned_string_set(
+            tree, "_PROTECTED_DAILY_ENERGY_KEYS"
+        ),
+        "_PROTECTED_LIFETIME_ENERGY_KEYS": _assigned_string_set(
+            tree, "_PROTECTED_LIFETIME_ENERGY_KEYS"
+        ),
+        "dt_util": SimpleNamespace(now=lambda: datetime(2026, 9, 3, 12, 0)),
+    }
+    exec(compile(module, SOURCE_PATH, "exec"), namespace)
+
+    sensor = SimpleNamespace(
+        entity_description=SimpleNamespace(key=key),
+        entity_id=f"sensor.{key}",
+        _last_valid_daily_energy_value=last,
+        _last_valid_daily_energy_date=datetime(2026, 9, 3).date(),
+        _is_near_daily_reset=lambda: near_reset,
+    )
+    return MethodType(namespace["_apply_energy_zero_guard"], sensor), sensor
+
+
 class TestEnergyZeroGuard(unittest.TestCase):
     """Ensure lifetime and daily energy counters keep distinct reset rules."""
 
@@ -52,41 +96,44 @@ class TestEnergyZeroGuard(unittest.TestCase):
             _assigned_string_set(tree, "_PROTECTED_DAILY_ENERGY_KEYS"),
         )
 
-    def test_midnight_reset_exception_is_limited_to_daily_energy(self) -> None:
-        tree = _source_tree()
-        sensor_class = next(
-            node
-            for node in tree.body
-            if isinstance(node, ast.ClassDef) and node.name == "SigenergySensor"
-        )
-        guard = next(
-            node
-            for node in sensor_class.body
-            if isinstance(node, ast.FunctionDef)
-            and node.name == "_apply_energy_zero_guard"
+    def test_lifetime_zero_after_positive_is_suppressed(self) -> None:
+        guard, sensor = _guard_for(
+            "dc_charger_total_charging_capacity",
+            last=Decimal("121.56"),
+            near_reset=False,
         )
 
-        midnight_calls = [
-            node
-            for node in ast.walk(guard)
-            if isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "_is_near_daily_reset"
-        ]
-        self.assertEqual(1, len(midnight_calls))
+        self.assertIsNone(guard(0))
+        self.assertEqual(Decimal("121.56"), sensor._last_valid_daily_energy_value)
 
-        midnight_if = next(
-            node
-            for node in ast.walk(guard)
-            if isinstance(node, ast.If)
-            and any(call is midnight_calls[0] for call in ast.walk(node.test))
+    def test_lifetime_zero_is_suppressed_near_midnight(self) -> None:
+        guard, _ = _guard_for(
+            "dc_charger_total_charging_capacity",
+            last=Decimal("121.56"),
+            near_reset=True,
         )
-        self.assertTrue(
-            any(
-                isinstance(node, ast.Name) and node.id == "is_daily"
-                for node in ast.walk(midnight_if.test)
-            )
+
+        self.assertIsNone(guard(0))
+
+    def test_daily_zero_is_accepted_near_midnight(self) -> None:
+        guard, sensor = _guard_for(
+            "plant_daily_pv_energy",
+            last=Decimal("15.2"),
+            near_reset=True,
         )
+
+        self.assertEqual(0, guard(0))
+        self.assertEqual(Decimal(0), sensor._last_valid_daily_energy_value)
+
+    def test_positive_lifetime_value_passes_through_and_is_remembered(self) -> None:
+        guard, sensor = _guard_for(
+            "dc_charger_total_charging_capacity",
+            last=None,
+            near_reset=False,
+        )
+
+        self.assertEqual(121.56, guard(121.56))
+        self.assertEqual(Decimal("121.56"), sensor._last_valid_daily_energy_value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- protect `dc_charger_total_charging_capacity` from transient zero readings after a positive value has been observed
- keep lifetime counters separate from daily counters so the midnight reset exception never applies to EVDC lifetime energy
- add behavioral regression tests for lifetime suppression and daily reset handling

## Background

The EVDC lifetime charging counter can briefly report `0` during a reconnect/read disturbance and then recover to its previous value. Home Assistant sees that recovery as a new increase, which can create a large false spike in downstream utility meters (including Predbat EV charging energy).

This follows the zero-bounce protection introduced for daily energy sensors in #338, while preserving the different reset semantics of a lifetime counter.

Observed sequence:

```text
121.56 kWh -> 0.0 kWh -> 121.56 kWh
```

No charging power was present during the sequence.

## Testing

```text
python3 -m unittest discover -s tests -v
Ran 7 tests in 0.047s
OK
```

The tests execute the guard behavior directly without requiring Home Assistant as a test dependency. `git diff --check` also passes.